### PR TITLE
pcs interleave option

### DIFF
--- a/library/pcs_resource.py
+++ b/library/pcs_resource.py
@@ -100,8 +100,7 @@ def main():
         cmd += ' --master'
 
     if module.params.has_key('interleave') and module.params['interleave'] == 'yes':
-        cmd += ' --interleave=true'
-
+        cmd += ' interleave=true'
 
     # Run command.
     cmd = cmd % module.params

--- a/roles/ceilometer-control/tasks/juno-cluster-resources.yml
+++ b/roles/ceilometer-control/tasks/juno-cluster-resources.yml
@@ -10,7 +10,7 @@
   tags: ceilometer
 
 - name: create pacemaker resources for ceilometer-collector
-  pcs_resource: command=create name=ceilometer-collector type=systemd:openstack-ceilometer-collector clone=yes
+  pcs_resource: command=create name=ceilometer-collector type=systemd:openstack-ceilometer-collector clone=yes interleave=yes
   args:
     operations:
       - action: monitor
@@ -20,7 +20,7 @@
   tags: ceilometer
 
 - name: create pacemaker resources for ceilometer-api
-  pcs_resource: command=create name=ceilometer-api type=systemd:openstack-ceilometer-api clone=yes
+  pcs_resource: command=create name=ceilometer-api type=systemd:openstack-ceilometer-api clone=yes interleave=yes
   args:
     operations:
       - action: monitor
@@ -30,7 +30,7 @@
   tags: ceilometer
 
 - name: create ceilometer-delay resource
-  pcs_resource: command=create name=ceilometer-delay type=Delay clone=yes
+  pcs_resource: command=create name=ceilometer-delay type=Delay clone=yes interleave=yes
   args:
     options:
       startdelay: 10
@@ -38,7 +38,7 @@
   tags: ceilometer
 
 - name: create pacemaker resources for ceilometer notification system
-  pcs_resource: command=create name={{ item }} type=systemd:openstack-{{ item }} clone=yes
+  pcs_resource: command=create name={{ item }} type=systemd:openstack-{{ item }} clone=yes interleave=yes
   args:
     operations:
       - action: monitor

--- a/roles/cinder/tasks/main.yml
+++ b/roles/cinder/tasks/main.yml
@@ -16,20 +16,20 @@
 - name: configure base cinder via openstack-config utility
   command: openstack-config --set --verbose /etc/cinder/cinder.conf {{item}}
   with_items:
-    - " database connection mysql://cinder:{{ cinder_db_pass }}@{{ lb_db_vip}}/cinder"
-    - " database max_retries -1"
-    - " DEFAULT auth_strategy keystone"
-    - " keystone_authtoken identity_uri {{ keystone_auth_protocol | default('http') }}://{{ keystone_admin_vip }}:{{ keystone_auth_port | default(35357) }}/"
-    - " keystone_authtoken auth_uri{{ keystone_public_protocol | default('http') }}://{{ keystone_public_vip }}:{{ keystone_public_port | default(5000) }}/"
-    - " keystone_authtoken admin_tenant_name services"
-    - " keystone_authtoken admin_user cinder"
-    - " keystone_authtoken admin_password {{ cinder_pass }}"
-    - " DEFAULT notification_driver messaging"
-    - " DEFAULT control_exchange cinder"
-    - " DEFAULT glance_host {{ glance_private_vip }}"
-    - " DEFAULT memcache_servers {{ memcache_list }}"
-    - " DEFAULT rabbit_hosts {{ rabbit_hosts }}"
-    - " DEFAULT rabbit_ha_queues true"
+    - "database connection mysql://cinder:{{ cinder_db_pass }}@{{ lb_db_vip}}/cinder"
+    - "database max_retries -1"
+    - "DEFAULT auth_strategy keystone"
+    - "keystone_authtoken identity_uri {{ keystone_auth_protocol | default('http') }}://{{ keystone_admin_vip }}:{{ keystone_auth_port | default(35357) }}/"
+    - "keystone_authtoken auth_uri{{ keystone_public_protocol | default('http') }}://{{ keystone_public_vip }}:{{ keystone_public_port | default(5000) }}/"
+    - "keystone_authtoken admin_tenant_name services"
+    - "keystone_authtoken admin_user cinder"
+    - "keystone_authtoken admin_password {{ cinder_pass }}"
+    - "DEFAULT notification_driver messaging"
+    - "DEFAULT control_exchange cinder"
+    - "DEFAULT glance_host {{ glance_private_vip }}"
+    - "DEFAULT memcache_servers {{ memcache_list }}"
+    - "DEFAULT rabbit_hosts {{ rabbit_hosts }}"
+    - "DEFAULT rabbit_ha_queues true"
   register: cmd
   changed_when: "'unchanged' not in cmd.stderr"
   tags: cinder
@@ -37,13 +37,13 @@
 - name: configure cinder nfs driver via openstack-config utility
   command: openstack-config --set --verbose /etc/cinder/cinder.conf {{item}}
   with_items:
-    - " DEFAULT host rhos6-cinder"
-    - " DEFAULT osapi_volume_listen {{ cinder_osapi_volume_listen }}"
-    - " DEFAULT osapi_volume_listen_port {{ cinder_osapi_volume_listen_port }}"
-    - " DEFAULT nfs_shares_config /etc/cinder/nfs_exports"
-    - " DEFAULT nfs_sparsed_volumes true"
-    - " DEFAULT nfs_mount_options v3"
-    - " DEFAULT volume_driver cinder.volume.drivers.nfs.NfsDriver"
+    - "DEFAULT host rhos6-cinder"
+    - "DEFAULT osapi_volume_listen {{ cinder_osapi_volume_listen }}"
+    - "DEFAULT osapi_volume_listen_port {{ cinder_osapi_volume_listen_port }}"
+    - "DEFAULT nfs_shares_config /etc/cinder/nfs_exports"
+    - "DEFAULT nfs_sparsed_volumes true"
+    - "DEFAULT nfs_mount_options v3"
+    - "DEFAULT volume_driver cinder.volume.drivers.nfs.NfsDriver"
   register: cmd
   when: use_cinder_nfs_volume_driver
   changed_when: "'unchanged' not in cmd.stderr"

--- a/roles/keystone/tasks/keystone_juno.yml
+++ b/roles/keystone/tasks/keystone_juno.yml
@@ -10,17 +10,17 @@
 # following requires that crudini .5-1 be installed from epel or it will fail.
 
 - name: set keystone configuration
-  command: openstack-config --verbose {{ item }}
+  command: openstack-config --verbose --set /etc/keystone/keystone.conf {{ item }}
   with_items:
-    - " --set /etc/keystone/keystone.conf DEFAULT admin_token {{keystone_admin_token}}"
-    - " --set /etc/keystone/keystone.conf DEFAULT rabbit_hosts {{rabbit_hosts}}"
-    - " --set /etc/keystone/keystone.conf DEFAULT rabbit_ha_queues true"
-    - " --set /etc/keystone/keystone.conf DEFAULT admin_endpoint http://{{ keystone_vip }}:35357"
-    - " --set /etc/keystone/keystone.conf DEFAULT public_endpoint http://{{ keystone_public_vip }}:{{keystone_public_port}}"
-    - " --set /etc/keystone/keystone.conf DEFAULT database connection mysql://keystone:{{keystone_db_pass}}@{{lb_db_vip}}/keystone"
-    - " --set /etc/keystone/keystone.conf database max_retries -1"
-    - " --set /etc/keystone/keystone.conf DEFAULT public_bind_host {{internal_ipaddr}}"
-    - " --set /etc/keystone/keystone.conf DEFAULT admin_bind_host {{internal_ipaddr}}"
+    - "DEFAULT admin_token {{keystone_admin_token}}"
+    - "DEFAULT rabbit_hosts {{rabbit_hosts}}"
+    - "DEFAULT rabbit_ha_queues true"
+    - "DEFAULT admin_endpoint http://{{ keystone_vip }}:35357"
+    - "DEFAULT public_endpoint http://{{ keystone_public_vip }}:{{keystone_public_port}}"
+    - "DEFAULT database connection mysql://keystone:{{keystone_db_pass}}@{{lb_db_vip}}/keystone"
+    - "database max_retries -1"
+    - "DEFAULT public_bind_host {{internal_ipaddr}}"
+    - "DEFAULT admin_bind_host {{internal_ipaddr}}"
   register: cmd
   changed_when: "'unchanged' not in cmd.stderr"
   tags: keystone


### PR DESCRIPTION
The interleave option for 'clone' should not have preceding dashes.
Added the option to the ceilometer tasks.
Updated consistency for a couple of files.
