### PR TITLE
adds glance image and security group support

### DIFF
--- a/roles/demo/defaults/main.yml
+++ b/roles/demo/defaults/main.yml
@@ -13,3 +13,13 @@ ext_allocation:
 int_net_name: internal_net
 int_network: 192.168.101.0/24
 router_name: rotuer-1
+copy_image: True
+image_location: /root/
+image_name: rhel-guest-image-7.1-20150224.0.x86_64.qcow2
+image_disk_format: qcow2
+image_short_name: rhel7.1
+image_root_password: redhat1234
+
+#boot options
+nova_boot_flavor: m1.small
+nova_boot_name: test_vm

--- a/roles/demo/tasks/image.yml
+++ b/roles/demo/tasks/image.yml
@@ -1,0 +1,31 @@
+---
+- name: copy image to controller1
+  copy: src={{image_location}}{{image_name}} dest=/root/{{image_name}}
+  tags: demo
+  run_once: true
+
+- name: add image to glance
+  command: >
+    glance {{os_admin_auth}}
+    --name {{image_short_name}}
+    --file /root/{{image_name}}
+    --disk-format {{image_disk_format}}
+    --disk-container bare
+    --is-public true
+  run_once: true
+  tags: demo
+
+- name: copy cloud-init demo
+  template: src=cloud_cfg_demo.txt.j2 dest=/root/cloud_cfg_demo.txt
+  tags: demo
+
+- name: launch an instance
+  command: >
+    nova {{os_demo_auth}}
+    --flavor {{nova_boot_flavor}}
+    name {{nova_boot_name}}
+    --user-data /root/cloud_cfg_demo.txt
+    --nic net-id={{internal_id.stdout}}
+    --security-groups ssh-icmp
+  run_once: true
+  tags: demo

--- a/roles/demo/tasks/main.yml
+++ b/roles/demo/tasks/main.yml
@@ -142,3 +142,37 @@
   run_once: true
   when: '"{{internal_id.stdout}}" not in cmd.stdout'
   tags: demo
+
+### create security group
+- name: create security group
+  shell: neutron {{os_demo_auth}} security-group-create ssh-icmp -- description "ssh and icmp allowed" | grep "id " | gawk -F' ' '{print $4}'
+  run_once: true
+  register: sec_uuid
+  tags: demo
+
+- name: create ssh inbound rule
+  command: >
+    neutron {{os_demo_auth}}
+    security-group-rule-create
+    --direction ingress
+    --protocol tcp
+    --port_range_min 22
+    --port-range_max 22
+    {{ sec_uuid.stdout }}
+  run_once: true
+  tags: demo
+
+- name: create ssh inbound rule
+  command: >
+    neutron {{os_demo_auth}}
+    security-group-rule-create
+    --direction ingress
+    --protocol icmp
+    {{ sec_uuid.stdout }}
+  run_once: true
+  tags: demo
+
+- name: start image task
+  include: image.yml
+  when: copy_image
+  tags: demo

--- a/roles/demo/templates/cloud_cfg_demo.txt.j2
+++ b/roles/demo/templates/cloud_cfg_demo.txt.j2
@@ -1,0 +1,14 @@
+#cloud-config
+#vim:syntax=yaml
+debug: True
+ssh_pwauth: True
+disable_root: false
+chpasswd:
+  list: |
+    root: {{image_root_password}}
+    centos: centOS
+    cloud-user: cloud
+  expire: false
+runcmd:
+- sed -i'.orig' -e's/without-password/yes/' /etc/ssh/sshd_config
+- service sshd restart


### PR DESCRIPTION
Adds an image (as specified in defaults/main.yml) to glance
creates security rule with port 22 and icmp
creates a cloud-init template file to use
launches a VM with the above options on internal nic in the demo tenant
