### PR TITLE
Mongodb fix

### DIFF
--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -31,8 +31,12 @@
 
 
 - name: load replica set config
-  template: src=repset_init.j2 dest=/tmp/repset_init.js
+  template: 
+    src: "repset_init.j2"
+    dest: "/tmp/repset_init.js"
+    force: yes
   tags: mongodb
+
 
 - name: initialize the replication set
   command: /usr/bin/mongo --host "{{ mongodb_bind_host }}" --port "{{ mongodb_port | default(27017) }}" /tmp/repset_init.js

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -37,7 +37,6 @@
     force: yes
   tags: mongodb
 
-
 - name: initialize the replication set
   command: /usr/bin/mongo --host "{{ mongodb_bind_host }}" --port "{{ mongodb_port | default(27017) }}" /tmp/repset_init.js
   run_once: true

--- a/roles/mongodb/templates/repset_init.j2
+++ b/roles/mongodb/templates/repset_init.j2
@@ -1,6 +1,6 @@
 rs.initiate()
 sleep(13000)
-{% for host in mongo_replSet  %}
-rs.add("{{ host }}:{{ mongodb_port | default(27017) }}")
+{% for host in groups['controller'][1:]  %}
+rs.add("{{ hostvars[host]['ansible_hostname'] }}:{{ mongodb_port | default(27017) }}")
 {% endfor %}
 printjson(rs.status())

--- a/roles/mongodb/vars/main.yml
+++ b/roles/mongodb/vars/main.yml
@@ -2,5 +2,3 @@
 public_ipaddr: "{{ hostvars[inventory_hostname][ 'ansible_' + primary_if ].ipv4.address }}"
 internal_ipaddr: "{{ hostvars[inventory_hostname][ 'ansible_' + private_if ].ipv4.address }}"
 mongodb_bind_host: "{{ internal_ipaddr }}"
-mongo_one: "{{hostvars[groups['controller'][0]]['ansible_hostname']}}"
-#mongo_replSet: "{% for node in groups['controller'] %}{% if (hostvars[node]['ansible_hostname'] != mongo_one) and not loop.last %}[{{ hostvars[node]['ansible_hostname'] }}], {% elif hostvars[node]['ansible_hostname'] != mongo_one) %}]{% endif %} {% endfor %}"

--- a/roles/mongodb/vars/main.yml
+++ b/roles/mongodb/vars/main.yml
@@ -3,4 +3,4 @@ public_ipaddr: "{{ hostvars[inventory_hostname][ 'ansible_' + primary_if ].ipv4.
 internal_ipaddr: "{{ hostvars[inventory_hostname][ 'ansible_' + private_if ].ipv4.address }}"
 mongodb_bind_host: "{{ internal_ipaddr }}"
 mongo_one: "{{hostvars[groups['controller'][0]]['ansible_hostname']}}"
-mongo_replSet: "{% for node in groups['controller'] %}{% if hostvars[node]['ansible_hostname'] != mongo_one %} {{ hostvars[node]['ansible_hostname'] }} {% endif %} {% endfor %}"
+#mongo_replSet: "{% for node in groups['controller'] %}{% if (hostvars[node]['ansible_hostname'] != mongo_one) and not loop.last %}[{{ hostvars[node]['ansible_hostname'] }}], {% elif hostvars[node]['ansible_hostname'] != mongo_one) %}]{% endif %} {% endfor %}"


### PR DESCRIPTION
resolved issue with mongodb replica sets.

TASK: [mongodb | create data directory for mongodb] ***************************
changed: [wiley-ctlr-2]
changed: [wiley-ctlr-3]
changed: [wiley-ctlr-1]

TASK: [mongodb | create pid directory for mongodb] ****************************
changed: [wiley-ctlr-2]
changed: [wiley-ctlr-3]
changed: [wiley-ctlr-1]

TASK: [mongodb | start mongodb] ***********************************************
changed: [wiley-ctlr-3]
changed: [wiley-ctlr-2]
changed: [wiley-ctlr-1]

TASK: [mongodb | load replica set config] *************************************
changed: [wiley-ctlr-2]
changed: [wiley-ctlr-3]
changed: [wiley-ctlr-1]

TASK: [mongodb | initialize the replication set] ******************************
changed: [wiley-ctlr-1]

TASK: [mongodb | pause to allow primary election and sync of replica set] *****
(^C-c = continue early, ^C-a = abort)
[wiley-ctlr-1, wiley-ctlr-2, wiley-ctlr-3]
Pausing for 60 seconds
ok: [wiley-ctlr-1]
