### PR TITLE
use a boolean switch to enable/disable the use of stonith

### DIFF
--- a/roles/pacemaker/defaults/main.yml
+++ b/roles/pacemaker/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+use_stonith: true

--- a/roles/pacemaker/tasks/main.yml
+++ b/roles/pacemaker/tasks/main.yml
@@ -66,17 +66,26 @@
   pause: seconds=30
   tags: pcs
 
+- name: disable stonith                
+  command: pcs property set stonith-enabled=false              
+  run_once: true               
+  ignore_errors: true          
+  tags: pcs
+  when: not use_stonith
+
 - name: create stonith resources
   shell: "pcs stonith show ipmilan-fence-{{item}} || pcs stonith create ipmilan-fence-{{item}}  fence_{{hostvars[item]['fencing_agent']}} pcmk_host_list={{item}} {{ hostvars[item]['fencing_params'] }}"
   with_items: groups['controller']
   run_once: true
   tags: pcs
+  when: use_stonith
 
 - name: create location constraint
   shell: "pcs constraint list --full | grep ipmilan-fence-{{ item }} || pcs constraint location ipmilan-fence-{{item}} avoids {{item}}"
   with_items: groups['controller']
   run_once: true
   tags: pcs
+  when: use_stonith
 
 - name: crm verify
   command: crm_verify -L


### PR DESCRIPTION
use a boolean switch to enable/disable the use of stonith

Testing, TASK: [pacemaker | pause to let pacemaker initialize resources] ***************
(^C-c = continue early, ^C-a = abort)
[wiley-ctlr-1, wiley-ctlr-2, wiley-ctlr-3]
Pausing for 30 seconds
ok: [wiley-ctlr-1]
TASK: [pacemaker | disable stonith] *******************************************
changed: [wiley-ctlr-1]
TASK: [pacemaker | create stonith resources] **********************************
skipping: [wiley-ctlr-1] => (item=wiley-ctlr-1)
skipping: [wiley-ctlr-1] => (item=wiley-ctlr-2)
skipping: [wiley-ctlr-1] => (item=wiley-ctlr-3)
TASK: [pacemaker | create location constraint] ********************************
skipping: [wiley-ctlr-1] => (item=wiley-ctlr-1)
skipping: [wiley-ctlr-1] => (item=wiley-ctlr-2)
skipping: [wiley-ctlr-1] => (item=wiley-ctlr-3)
TASK: [pacemaker | crm verify] ************************************************
changed: [wiley-ctlr-1]
