### PR TITLE
Convert stonith resource task to use existing variables

### DIFF
--- a/roles/pacemaker/tasks/main.yml
+++ b/roles/pacemaker/tasks/main.yml
@@ -65,7 +65,16 @@
   when: not use_stonith
 
 - name: create stonith resources
-  shell: "pcs stonith show ipmilan-fence-{{item}} || pcs stonith create ipmilan-fence-{{item}}  fence_{{hostvars[item]['fencing_agent']}} pcmk_host_list={{item}} {{ hostvars[item]['fencing_params'] }}"
+  shell: >
+    pcs stonith show ipmilan-fence-{{item}} ||
+    pcs stonith create ipmilan-fence-{{item}} fence_ipmilan
+      pcmk_host_list={{item}}
+      login={{ipmi_username}}
+      passwd={{ipmi_password}}
+      ipaddr={{hostvars[item]['ipmi_ip_address']}}
+      lanplus=1
+      cipher=1
+      op monitor interval=60s
   with_items: groups['controller']
   run_once: true
   tags: pcs


### PR DESCRIPTION
This PR cleans up variable usage from inventory to use existing vars.

These two vars will be removed from the controllers in the wiley inventory in a separate PR:

```
fencing_agent: ipmilan
fencing_params: "login=root passwd=calvin ipaddr=172.30.0.72 lanplus=1 cipher=1 op monitor interval=60s"
```

I removed of the fencing_agent var because other aspects of how the resources were created depended on the fencing agent type.  Should we want to support other fencing agents in the future we can rework this task.

Testing:

```
PLAY RECAP ********************************************************************
auto-deploy-node           : ok=3    changed=0    unreachable=0    failed=0
compute-1                  : ok=99   changed=64   unreachable=0    failed=0
controller-1               : ok=389  changed=282  unreachable=0    failed=0
controller-2               : ok=393  changed=287  unreachable=0    failed=0
controller-3               : ok=393  changed=287  unreachable=0    failed=0
scaleio-1                  : ok=69   changed=43   unreachable=0    failed=0
scaleio-2                  : ok=69   changed=43   unreachable=0    failed=0
scaleio-3                  : ok=67   changed=41   unreachable=0    failed=0
swift-1                    : ok=94   changed=59   unreachable=0    failed=0
swift-2                    : ok=94   changed=59   unreachable=0    failed=0
swift-3                    : ok=94   changed=59   unreachable=0    failed=0


real    53m2.117s
user    3m20.592s
sys     1m42.357s
```

Times above represent a full build where site_deploy only configured the hosts because they had already been deployed.
