### PR TITLE
fixed issue where corosync lost connection

### DIFF
--- a/roles/pacemaker/tasks/main.yml
+++ b/roles/pacemaker/tasks/main.yml
@@ -1,14 +1,12 @@
 ---
 - name: insert iptable rules for pacemaker
   iptables:
-    port: "{{item}}"
-    protocol: tcp
+    port: "{{item.port}}"
+    protocol: "{{item.protocol}}"
     comment: "Pacemaker ports"
   with_items:
-    - 2224
-    - 3121
-    - 21064
-    - 5405
+    - {port: [2224,3121,21064], protocol: tcp}
+    - {port: 5405, protocol: udp}
   tags:
     - pcs
     - iptables


### PR DESCRIPTION
Corosync needs Port UDP 5405 open, currently the iptables rule is for TCP 5405

```
Perform task: pacemaker | insert iptable rules for pacemaker (y/n/c):  ********
changed: [controller-2] => (item={'protocol': 'tcp', 'port': [2224, 3121, 21064]}) => {"changed": true, "item": {"port": [2224, 3121, 21064], "protocol": "tcp"}, "msg": "INPUT -p tcp -m multiport --dport 2224,3121,21064 -m comment --comment \" Pacemaker ports\""}
changed: [controller-3] => (item={'protocol': 'tcp', 'port': [2224, 3121, 21064]}) => {"changed": true, "item": {"port": [2224, 3121, 21064], "protocol": "tcp"}, "msg": "INPUT -p tcp -m multiport --dport 2224,3121,21064 -m comment --comment \" Pacemaker ports\""}
changed: [controller-1] => (item={'protocol': 'tcp', 'port': [2224, 3121, 21064]}) => {"changed": true, "item": {"port": [2224, 3121, 21064], "protocol": "tcp"}, "msg": "INPUT -p tcp -m multiport --dport 2224,3121,21064 -m comment --comment \" Pacemaker ports\""}
changed: [controller-3] => (item={'protocol': 'udp', 'port': 5405}) => {"changed": true, "item": {"port": 5405, "protocol": "udp"}, "msg": "INPUT -p udp --dport 5405 -m comment --comment \" Pacemaker ports\""}
changed: [controller-2] => (item={'protocol': 'udp', 'port': 5405}) => {"changed": true, "item": {"port": 5405, "protocol": "udp"}, "msg": "INPUT -p udp --dport 5405 -m comment --comment \" Pacemaker ports\""}
changed: [controller-1] => (item={'protocol': 'udp', 'port': 5405}) => {"changed": true, "item": {"port": 5405, "protocol": "udp"}, "msg": "INPUT -p udp --dport 5405 -m comment --comment \" Pacemaker ports\""}
```

```
root@controller-1 ~]# pcs status
Cluster name: automation_cluster
Last updated: Wed Oct 14 11:24:33 2015      Last change: Wed Oct 14 10:34:51 2015 by root via cibadmin on controller-1
Stack: corosync
Current DC: controller-1 (version 1.1.13-a14efad) - partition with quorum
3 nodes and 121 resources configured

Online: [ controller-1 controller-2 controller-3 ]
```
