### PR TITLE
Swift disk fix

### DIFF
--- a/roles/swift-storage-1/tasks/juno.yml
+++ b/roles/swift-storage-1/tasks/juno.yml
@@ -114,7 +114,8 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder account.builder add z{{zone_id}}-{{ int_if.ipaddr }}:6202/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[inventory_hostname].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   ignore_errors: yes
   tags: swift
 
@@ -124,7 +125,8 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][0]].zone_id }}-{{ hostvars[groups['swift'][0]].int_if.ipaddr }}:6201/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][0]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
 
@@ -133,7 +135,8 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][1]].zone_id }}-{{ hostvars[groups['swift'][1]].int_if.ipaddr }}:6201/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][1]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
 
@@ -141,7 +144,8 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][2]].zone_id }}-{{ hostvars[groups['swift'][2]].int_if.ipaddr }}:6201/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][2]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
 
@@ -149,7 +153,8 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][0]].zone_id}}-{{ hostvars[groups['swift'][0]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][0]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
 
@@ -157,7 +162,8 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][1]].zone_id}}-{{ hostvars[groups['swift'][1]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][1]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
 
@@ -165,6 +171,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][2]].zone_id}}-{{ hostvars[groups['swift'][2]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][2]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift

--- a/roles/swift-storage-1/tasks/kilo.yml
+++ b/roles/swift-storage-1/tasks/kilo.yml
@@ -100,41 +100,69 @@
   tags: swift
 
 # create the rings on the controller1
+# create the rings on the controller1
 - name: create account ring
   delegate_to: "{{ groups['controller'][0] }}"
-  command: swift-ring-builder account.builder add z1-{{ int_if.ipaddr }}:6202/{{ item }} 100
+  command: swift-ring-builder account.builder add z{{zone_id}}-{{ int_if.ipaddr }}:6202/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[inventory_hostname].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   ignore_errors: yes
   tags: swift
 
-- name: create container ring
+
+
+- name: add container ring 1
   delegate_to: "{{ groups['controller'][0] }}"
-  command: swift-ring-builder container.builder add z1-{{ int_if.ipaddr }}:6201/{{ item }} 100
+  command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][0]].zone_id }}-{{ hostvars[groups['swift'][0]].int_if.ipaddr }}:6201/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[inventory_hostname].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
+  run_once: true
+  tags: swift
+
+
+- name: add container ring 2
+  delegate_to: "{{ groups['controller'][0] }}"
+  command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][1]].zone_id }}-{{ hostvars[groups['swift'][1]].int_if.ipaddr }}:6201/{{ item }} 100
+           chdir=/etc/swift
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
+  run_once: true
+  tags: swift
+
+- name: add container ring 3
+  delegate_to: "{{ groups['controller'][0] }}"
+  command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][2]].zone_id }}-{{ hostvars[groups['swift'][2]].int_if.ipaddr }}:6201/{{ item }} 100
+           chdir=/etc/swift
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
+  run_once: true
   tags: swift
 
 - name: create object ring 1
   delegate_to: "{{ groups['controller'][0] }}"
-  command: swift-ring-builder object.builder add z1-{{ hostvars[groups['swift'][0]].int_if.ipaddr }}:6200/{{ item }} 100
+  command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][0]].zone_id}}-{{ hostvars[groups['swift'][0]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][0]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
 
 - name: create object ring 2
   delegate_to: "{{ groups['controller'][0] }}"
-  command: swift-ring-builder object.builder add z1-{{ hostvars[groups['swift'][1]].int_if.ipaddr }}:6200/{{ item }} 100
+  command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][1]].zone_id}}-{{ hostvars[groups['swift'][1]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][1]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
 
 - name: create object ring 3
   delegate_to: "{{ groups['controller'][0] }}"
-  command: swift-ring-builder object.builder add z1-{{ hostvars[groups['swift'][2]].int_if.ipaddr }}:6200/{{ item }} 100
+  command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][2]].zone_id}}-{{ hostvars[groups['swift'][2]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: hostvars[groups['swift'][2]].swift_data_disks
+  with_items: pdisk
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift


### PR DESCRIPTION
Fixed issues where swift-storage-1 failed to to missing variables

```
TASK: [openstack-compute | fail msg="Ubuntu is currently not supported"] ******
skipping: [compute-1]

PLAY RECAP ********************************************************************
auto-deploy-node           : ok=3    changed=3    unreachable=0    failed=0
compute-1                  : ok=105  changed=69   unreachable=0    failed=0
controller-1               : ok=413  changed=300  unreachable=0    failed=0
controller-2               : ok=417  changed=305  unreachable=0    failed=0
controller-3               : ok=417  changed=305  unreachable=0    failed=0
scaleio-1                  : ok=79   changed=52   unreachable=0    failed=0
scaleio-2                  : ok=79   changed=52   unreachable=0    failed=0
scaleio-3                  : ok=77   changed=50   unreachable=0    failed=0
swift-1                    : ok=102  changed=64   unreachable=0    failed=0
swift-2                    : ok=102  changed=64   unreachable=0    failed=0
swift-3                    : ok=102  changed=64   unreachable=0    failed=0
```
