### PR TITLE
Nga 478

### DIFF
--- a/ceph-nodes.yml
+++ b/ceph-nodes.yml
@@ -2,7 +2,7 @@
 - hosts: ceph
   roles:
     - { role: iface, device: "{{bond_device[0]}}", params: { type: Ethernet, bootproto: none, onboot: '"yes"', master: bond0, slave: '"yes"' } }
-    - { role: iface, device: "{{bond_device[0]}}", params: { type: Ethernet, bootproto: none, onboot: '"yes"', master: bond0, slave: '"yes"' } }
+    - { role: iface, device: "{{bond_device[1]}}", params: { type: Ethernet, bootproto: none, onboot: '"yes"', master: bond0, slave: '"yes"' } }
     - { role: iface, device: bond0, params: { nozeroconf: '"yes"', bootproto: none, bonding_opts: '"mode=4 miimon=100 lacp_rate=1"', onboot: yes } }
     - { role: iface, device: "bond0.{{ int_if.vlan }}", params: { type: Ethernet, vlan: '"yes"', nozeroconf: '"yes"', bootproto: static, ipaddr: "{{ int_if.ipaddr }}", netmask: "{{ int_if.netmask }}", onboot: '"yes"' } }
     - { role: iface, device: "bond0.{{ storage_if.vlan }}", params: { type: Ethernet, vlan: '"yes"', nozeroconf: '"yes"', bootproto: static, ipaddr: "{{ storage_if.ipaddr }}", netmask: "{{ storage_if.netmask }}", onboot: '"yes"' } }

--- a/ceph-nodes.yml
+++ b/ceph-nodes.yml
@@ -1,8 +1,8 @@
 ---
 - hosts: ceph
   roles:
-    - { role: iface, device: p4p1, params: { type: Ethernet, bootproto: none, onboot: '"yes"', master: bond0, slave: '"yes"' } }
-    - { role: iface, device: p4p2, params: { type: Ethernet, bootproto: none, onboot: '"yes"', master: bond0, slave: '"yes"' } }
+    - { role: iface, device: "{{bond_device[0]}}", params: { type: Ethernet, bootproto: none, onboot: '"yes"', master: bond0, slave: '"yes"' } }
+    - { role: iface, device: "{{bond_device[0]}}", params: { type: Ethernet, bootproto: none, onboot: '"yes"', master: bond0, slave: '"yes"' } }
     - { role: iface, device: bond0, params: { nozeroconf: '"yes"', bootproto: none, bonding_opts: '"mode=4 miimon=100 lacp_rate=1"', onboot: yes } }
     - { role: iface, device: "bond0.{{ int_if.vlan }}", params: { type: Ethernet, vlan: '"yes"', nozeroconf: '"yes"', bootproto: static, ipaddr: "{{ int_if.ipaddr }}", netmask: "{{ int_if.netmask }}", onboot: '"yes"' } }
     - { role: iface, device: "bond0.{{ storage_if.vlan }}", params: { type: Ethernet, vlan: '"yes"', nozeroconf: '"yes"', bootproto: static, ipaddr: "{{ storage_if.ipaddr }}", netmask: "{{ storage_if.netmask }}", onboot: '"yes"' } }

--- a/compute-nodes.yml
+++ b/compute-nodes.yml
@@ -4,7 +4,7 @@
   max_fail_percentage: 0
   roles:
     - role: iface
-      device: p3p1
+      device: "{{bond_device[0]}}"
       params:
         type: Ethernet
         bootproto: none
@@ -14,7 +14,7 @@
         slave: '"yes"'
 
     - role: iface
-      device: p3p2
+      device: "{{bond_device[0]}}"
       params:
         type: Ethernet
         bootproto: none

--- a/compute-nodes.yml
+++ b/compute-nodes.yml
@@ -14,7 +14,7 @@
         slave: '"yes"'
 
     - role: iface
-      device: "{{bond_device[0]}}"
+      device: "{{bond_device[1]}}"
       params:
         type: Ethernet
         bootproto: none

--- a/controllers.yml
+++ b/controllers.yml
@@ -4,7 +4,7 @@
   max_fail_percentage: 0
   roles:
     - role: iface
-      device: p3p1
+      device: "{{bond_device[0]}}"
       params:
         type: Ethernet
         bootproto: none
@@ -14,7 +14,7 @@
         slave: '"yes"'
 
     - role: iface
-      device: p3p2
+      device: "{{bond_device[0]}}"
       params:
         type: Ethernet
         bootproto: none

--- a/controllers.yml
+++ b/controllers.yml
@@ -14,7 +14,7 @@
         slave: '"yes"'
 
     - role: iface
-      device: "{{bond_device[0]}}"
+      device: "{{bond_device[1]}}"
       params:
         type: Ethernet
         bootproto: none

--- a/database.yml
+++ b/database.yml
@@ -1,5 +1,0 @@
----
-- hosts: mysql
-  roles:
-    - common
-    - mysql

--- a/roles/demo/defaults/main.yml
+++ b/roles/demo/defaults/main.yml
@@ -5,14 +5,8 @@ admin_tenant: admin
 demo_user: admin
 demo_tenant: demo
 ext_net_name: external
-ext_gateway: 172.17.21.1
-ext_network: 172.17.21.0/24
-ext_allocation:
-  start: 172.17.21.100
-  end: 172.17.21.200
 int_net_name: internal_net
-int_network: 192.168.101.0/24
-router_name: rotuer-1
+router_name: demo_router-1
 copy_image: True
 image_location: /root/
 image_name: rhel-guest-image-7.1-20150224.0.x86_64.qcow2

--- a/roles/demo/tasks/main.yml
+++ b/roles/demo/tasks/main.yml
@@ -64,10 +64,10 @@
     {{os_admin_auth}}
     subnet-create {{ext_net_name}}
     --gateway {{ext_gateway}}
-    --allocation-pool start={{ext_allocation.start}},end={{ext_allocation.end}}
+    --allocation-pool start={{start_ext_allocation}},end={{end_ext_allocation}}
     --disable-dhcp
-    {{ext_network}}
-  when: '"{{ext_network}}" not in cmd.stdout'
+    {{demo_ext_network}}
+  when: '"{{demo_ext_network}}" not in cmd.stdout'
   run_once: true
   tags: demo
 
@@ -92,9 +92,9 @@
     neutron
     {{os_demo_auth}}
     subnet-create
-    {{int_net_name}} {{int_network}}
+    {{int_net_name}} {{demo_int_network}}
   run_once: true
-  when: '"{{int_network}}" not in cmd.stdout'
+  when: '"{{demo_int_network}}" not in cmd.stdout'
   tags: demo
 
 - name: get internal network ID

--- a/roles/demo/vars/main.yml
+++ b/roles/demo/vars/main.yml
@@ -1,7 +1,6 @@
 #keystone_adminurl: "{{ keystone_auth_protocol }}://{{ keystone_vip }}:{{ keystone_auth_port }}/v2.0"
 os_admin_auth: "--os-auth-url {{ keystone_adminurl}} --os-tenant-name {{admin_tenant}} --os-username {{admin_user }}  --os-password {{admin_pass}}"
 os_demo_auth: "--os-auth-url {{ keystone_adminurl}} --os-tenant-name {{demo_tenant}} --os-username {{demo_user }}  --os-password {{admin_pass}}"
-ext_gateway: "{{demo_ext_network | ipaddr('net') | ipaddr('1')}}"
-ext_allocation:
-  start: "{{demo_ext_network | ipaddr('net') | ipaddr('100')}}"
-  end: "{{demo_ext_network | ipaddr('net') | ipaddr('200')}}"
+ext_gateway: "{{demo_ext_network | ipaddr('net') | ipaddr('1') | ipaddr('address')}}"
+start_ext_allocation: "{{demo_ext_network | ipaddr('net') | ipaddr('100') | ipaddr('address')}}" 
+end_ext_allocation: "{{demo_ext_network | ipaddr('net') | ipaddr('200') | ipaddr('address')}}" 

--- a/roles/demo/vars/main.yml
+++ b/roles/demo/vars/main.yml
@@ -1,3 +1,7 @@
 #keystone_adminurl: "{{ keystone_auth_protocol }}://{{ keystone_vip }}:{{ keystone_auth_port }}/v2.0"
 os_admin_auth: "--os-auth-url {{ keystone_adminurl}} --os-tenant-name {{admin_tenant}} --os-username {{admin_user }}  --os-password {{admin_pass}}"
 os_demo_auth: "--os-auth-url {{ keystone_adminurl}} --os-tenant-name {{demo_tenant}} --os-username {{demo_user }}  --os-password {{admin_pass}}"
+ext_gateway: "{{demo_ext_network | ipaddr('net') | ipaddr('1')}}"
+ext_allocation:
+  start: "{{demo_ext_network | ipaddr('net') | ipaddr('100')}}"
+  end: "{{demo_ext_network | ipaddr('net') | ipaddr('200')}}"

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,0 +1,1 @@
+haproxy_admin_pass: "{{ site_password }}"

--- a/roles/haproxy/templates/juno.haproxy.cfg.j2
+++ b/roles/haproxy/templates/juno.haproxy.cfg.j2
@@ -13,7 +13,7 @@ listen stats :8888
     stats realm Haproxy\ Statistics
     stats uri /
     stats enable
-
+    stats auth admin:{{ haproxy_admin_pass }}
 
 frontend vip-db
     bind {{ lb_db_vip }}:3306

--- a/roles/haproxy/templates/kilo.haproxy.cfg.j2
+++ b/roles/haproxy/templates/kilo.haproxy.cfg.j2
@@ -13,7 +13,7 @@ listen stats :8888
     stats realm Haproxy\ Statistics
     stats uri /
     stats enable
-    stats auth admin:wileyfuse
+    stats auth admin:{{ haproxy_admin_pass }}
 
 frontend vip-db
     bind {{ lb_db_vip }}:3306

--- a/roles/subscription-manager/tasks/offline.yml
+++ b/roles/subscription-manager/tasks/offline.yml
@@ -2,5 +2,5 @@
 - name: get repo file
   get_url:
     url: "http://{{auto_deploy_node}}/offline.repo"
-    dest: /etc/yum.repos.d/kragle_offline.repo
+    dest: /etc/yum.repos.d/offline.repo
     force: yes

--- a/scaleio-nodes.yml
+++ b/scaleio-nodes.yml
@@ -4,7 +4,7 @@
   max_fail_percentage: 0
   roles:
     - role: iface
-      device: p4p1
+      device: "{{bond_device[0]}}"
       params:
         type: Ethernet
         bootproto: none
@@ -14,7 +14,7 @@
         slave: '"yes"'
 
     - role: iface
-      device: p4p2
+      device: "{{bond_device[1]}}"
       params:
         type: Ethernet
         bootproto: none

--- a/swift.yml
+++ b/swift.yml
@@ -4,7 +4,7 @@
   max_fail_percentage: 0
   roles:
     - role: iface
-      device: p3p1
+      device: "{{bond_device[0]}}"
       params:
         type: Ethernet
         bootproto: none
@@ -14,7 +14,7 @@
         slave: '"yes"'
 
     - role: iface
-      device: p3p2
+      device: "{{bond_device[0]}}"
       params:
         type: Ethernet
         bootproto: none

--- a/swift.yml
+++ b/swift.yml
@@ -14,7 +14,7 @@
         slave: '"yes"'
 
     - role: iface
-      device: "{{bond_device[0]}}"
+      device: "{{bond_device[1]}}"
       params:
         type: Ethernet
         bootproto: none


### PR DESCRIPTION
NGA-478

issues in PR:
Removed static haproxy admin password
changed Static Network Devices, to a variable that is in host_vars
moved the demo ip address from defaults to group_vars inventory

This failed in testing after slimer run completed (it failed on the mdm part of scaleio)

```
TASK: [mdm | login with new password] *****************************************
fatal: [scaleio-2] => error while evaluating conditional: initial_login.rc == 7

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/root/site.retry

auto-deploy-node           : ok=3    changed=0    unreachable=0    failed=0
compute-1                  : ok=87   changed=55   unreachable=0    failed=0
controller-1               : ok=376  changed=273  unreachable=0    failed=0
controller-2               : ok=380  changed=278  unreachable=0    failed=0
controller-3               : ok=380  changed=278  unreachable=0    failed=0
scaleio-1                  : ok=44   changed=29   unreachable=0    failed=1
scaleio-2                  : ok=54   changed=33   unreachable=0    failed=1
scaleio-3                  : ok=45   changed=30   unreachable=0    failed=0
swift-1                    : ok=92   changed=56   unreachable=0    failed=0
swift-2                    : ok=92   changed=56   unreachable=0    failed=0
swift-3                    : ok=92   changed=56   unreachable=0    failed=0
```
