### PR TITLE
Nga 496

### DIFF
--- a/roles/horizon/tasks/juno.yml
+++ b/roles/horizon/tasks/juno.yml
@@ -81,6 +81,6 @@
     - memcached
   tags: horizon
 
-- name: restart openstack-nova-consoleauth
-  command: pcs resource restart openstack-nova-consoleauth
+- name: restart nova-consoleauth
+  command: pcs resource restart nova-consoleauth
   tags: horizon

--- a/roles/horizon/tasks/juno.yml
+++ b/roles/horizon/tasks/juno.yml
@@ -83,4 +83,5 @@
 
 - name: restart nova-consoleauth
   command: pcs resource restart nova-consoleauth
+  run_once: true  
   tags: horizon

--- a/roles/horizon/tasks/juno.yml
+++ b/roles/horizon/tasks/juno.yml
@@ -76,8 +76,11 @@
 - name: restart horizon
   service: name={{ item }} state=restarted
   with_items:
-    - openstack-nova-consoleauth
     - openstack-nova-novncproxy
     - httpd
     - memcached
+  tags: horizon
+
+- name: restart openstack-nova-consoleauth
+  command: pcs resource restart openstack-nova-consoleauth
   tags: horizon

--- a/roles/horizon/tasks/kilo.yml
+++ b/roles/horizon/tasks/kilo.yml
@@ -62,10 +62,14 @@
   tags: horizon
 
 - name: restart horizon
-  service: name={{ item }} state=restarted enabled=yes
+  service: name={{ item }} state=restarted
   with_items:
-    - openstack-nova-consoleauth
     - openstack-nova-novncproxy
     - httpd
     - memcached
+  tags: horizon
+
+- name: restart nova-consoleauth
+  command: pcs resource restart nova-consoleauth
+  run_once: true
   tags: horizon


### PR DESCRIPTION
This fixes a bug where openstack-nova-consoleauth fails to restart after configuring Horizon becuase it is restarted via systemd.  consoleauth is not cloned and is controlled by PCS so this was causing 2 extra copies of consoleauth to be started and created a possible race condition

error:

```
TASK: [horizon | restart horizon] *********************************************
changed: [controller-2] => (item=openstack-nova-consoleauth) => {"changed": true, "item": "openstack-nova-consoleauth", "name": "openstack-nova-consoleauth", "state": "started"}
changed: [controller-3] => (item=openstack-nova-consoleauth) => {"changed": true, "item": "openstack-nova-consoleauth", "name": "openstack-nova-consoleauth", "state": "started"}
changed: [controller-2] => (item=openstack-nova-novncproxy) => {"changed": true, "item": "openstack-nova-novncproxy", "name": "openstack-nova-novncproxy", "state": "started"}
changed: [controller-3] => (item=openstack-nova-novncproxy) => {"changed": true, "item": "openstack-nova-novncproxy", "name": "openstack-nova-novncproxy", "state": "started"}
failed: [controller-1] => (item=openstack-nova-consoleauth) => {"failed": true, "item": "openstack-nova-consoleauth"}
msg: Job for openstack-nova-consoleauth.service canceled.
```

The restart command was moved to within pcs to handle this properly.
testing:

```
2015-10-20 22:49:02,609 p=19670 u=root |  TASK: [horizon | restart horizon] *********************************************
2015-10-20 22:49:02,837 p=19670 u=root |  changed: [controller-3] => (item=openstack-nova-novncproxy) => {"changed": true, "item": "openstack-nova-novncproxy", "name": "openstack-nova-novncproxy", "state": "started"}
2015-10-20 22:49:02,838 p=19670 u=root |  changed: [controller-2] => (item=openstack-nova-novncproxy) => {"changed": true, "item": "openstack-nova-novncproxy", "name": "openstack-nova-novncproxy", "state": "started"}
2015-10-20 22:49:02,950 p=19670 u=root |  changed: [controller-1] => (item=openstack-nova-novncproxy) => {"changed": true, "item": "openstack-nova-novncproxy", "name": "openstack-nova-novncproxy", "state": "started"}
2015-10-20 22:49:03,049 p=19670 u=root |  changed: [controller-2] => (item=httpd) => {"changed": true, "item": "httpd", "name": "httpd", "state": "started"}
2015-10-20 22:49:03,050 p=19670 u=root |  changed: [controller-3] => (item=httpd) => {"changed": true, "item": "httpd", "name": "httpd", "state": "started"}
2015-10-20 22:49:03,216 p=19670 u=root |  changed: [controller-2] => (item=memcached) => {"changed": true, "item": "memcached", "name": "memcached", "state": "started"}
2015-10-20 22:49:03,216 p=19670 u=root |  changed: [controller-3] => (item=memcached) => {"changed": true, "item": "memcached", "name": "memcached", "state": "started"}
2015-10-20 22:49:04,568 p=19670 u=root |  changed: [controller-1] => (item=httpd) => {"changed": true, "item": "httpd", "name": "httpd", "state": "started"}
2015-10-20 22:49:04,860 p=19670 u=root |  changed: [controller-1] => (item=memcached) => {"changed": true, "item": "memcached", "name": "memcached", "state": "started"}
2015-10-20 22:49:04,870 p=19670 u=root |  TASK: [horizon | restart nova-consoleauth] ************************************
2015-10-20 22:49:12,878 p=19670 u=root |  changed: [controller-1] => {"changed": true, "cmd": ["pcs", "resource", "restart", "nova-consoleauth"], "delta": "0:00:07.713659", "end": "2015-10-20 20:49:12.357119", "rc": 0, "start": "2015-10-20 20:49:04.643460", "stderr": "", "stdout": "nova-consoleauth successfully restarted", "warnings": []}
```
