### PR TITLE
Remove crudini update and epel repo installation

### DIFF
--- a/roles/common/tasks/RedHat-rpms.yml
+++ b/roles/common/tasks/RedHat-rpms.yml
@@ -15,11 +15,3 @@
     - openstack-utils
     - vim
 
-# this is needed to track changes using openstack-config
-- name: add epel repo
-  copy: src=epel.repo dest=/etc/yum.repos.d/epel.repo
-  tags: crudini_update
-
-- name: update crudini
-  yum: name=crudini state=latest disable_gpg_check=yes enablerepo=epel
-  tags: crudini_update

--- a/roles/keystone/tasks/juno.yml
+++ b/roles/keystone/tasks/juno.yml
@@ -21,8 +21,6 @@
     - httpd
   tags: keystone
 
-# following requires that crudini .5-1 be installed from epel or it will fail.
-
 - name: configure the keystone.conf file
   ini_file:
     dest: /etc/keystone/keystone.conf


### PR DESCRIPTION
With the use of the ini_file module crudini verbose mode was no longer needed, and the update of crudini from the epel repo was no longer needed.

This is not tested as crudini is not used anywhere in slimer:

![screen shot 2015-10-27 at 10 21 32 am](https://cloud.githubusercontent.com/assets/11165839/10760755/8fac4180-7c94-11e5-9c7b-2b31b45f3f94.png)
