### PR TITLE
removed openstack-config

### DIFF
--- a/roles/cinder/tasks/juno.yml
+++ b/roles/cinder/tasks/juno.yml
@@ -52,7 +52,7 @@
     - { section: "database", option: "max_retries", value: "-1"}
   tags: cinder
 
-- name: Update configure cinder nfs driver via openstack-config utility
+- name: Update configure cinder nfs driver
   ini_file:
     dest: /etc/cinder/cinder.conf
     section: "{{ item.section }}"

--- a/roles/nova-compute/tasks/juno.yml
+++ b/roles/nova-compute/tasks/juno.yml
@@ -59,22 +59,26 @@
   when: use_nova_shared_backend
   tags: nova
 
-- name: modify libvirtd parameters with openstack-config
-  command: openstack-config --verbose --set /etc/sysconfig/libvirtd '' LIBVIRTD_ARGS '"--listen"'
-  register: cmd
-  changed_when: "'unchanged' not in cmd.stderr"
+- name: modify libvirtd parameters
+  ini_file:
+    dest: /etc/sysconfig/libvirtd
+    section: ""
+    option: 'LIBVERTD_ARGS'
+    value: '"--listen"'
   when: nova_instance_live_migration
   tags: nova
 
-- name: modify libvirtd.conf parameters with openstack-config
-  command: openstack-config --verbose --set /etc/libvirt/libvirtd.conf {{ item }}
+- name: modify libvirtd.conf parameters
+  ini_file:
+    dest: /etc/libvirt/libvirtd.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
   with_items:
-    - "DEFAULT verbose true"
-    - "'' listen_tls 0"
-    - "'' listen_tcp 1"
-    - "'' auth_tcp none"
-  register: cmd
-  changed_when: "'unchanged' not in cmd.stderr"
+    - { section: "DEFAULT", option: "verbose", value: "true"}
+    - { section: "", option: "listen_tls", value: "0"}
+    - { section: "", option: "auth_tcp", value: "none"}
+    - { section: "", option: "listen_tcp", value: "1"}
   when: nova_instance_live_migration
   tags: nova
 

--- a/roles/nova-compute/tasks/kilo.yml
+++ b/roles/nova-compute/tasks/kilo.yml
@@ -59,22 +59,26 @@
   when: use_nova_shared_backend
   tags: nova
 
-- name: modify libvirtd parameters with openstack-config
-  command: openstack-config --verbose --set /etc/sysconfig/libvirtd '' LIBVIRTD_ARGS '"--listen"'
-  register: cmd
-  changed_when: "'unchanged' not in cmd.stderr"
+- name: modify libvirtd parameters
+  ini_file:
+    dest: /etc/sysconfig/libvirtd
+    section: ""
+    option: 'LIBVERTD_ARGS'
+    value: '"--listen"'
   when: nova_instance_live_migration
   tags: nova
 
-- name: modify libvirtd.conf parameters with openstack-config
-  command: openstack-config --verbose --set /etc/libvirt/libvirtd.conf {{ item }}
+- name: modify libvirtd.conf parameters
+  ini_file:
+    dest: /etc/libvirt/libvirtd.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
   with_items:
-    - "DEFAULT verbose true"
-    - "'' listen_tls 0"
-    - "'' listen_tcp 1"
-    - "'' auth_tcp none"
-  register: cmd
-  changed_when: "'unchanged' not in cmd.stderr"
+    - { section: "DEFAULT", option: "verbose", value: "true"}
+    - { section: "", option: "listen_tls", value: "0"}
+    - { section: "", option: "auth_tcp", value: "none"}
+    - { section: "", option: "listen_tcp", value: "1"}
   when: nova_instance_live_migration
   tags: nova
 

--- a/roles/nova-control/tasks/juno.yml
+++ b/roles/nova-control/tasks/juno.yml
@@ -27,47 +27,49 @@
   tags: nova
 
 - name: Update nova.conf file
-  command: openstack-config --verbose --set /etc/nova/nova.conf {{ item }}
+  ini_file:
+    dest: /etc/nova/nova.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
   with_items:
-    - "DEFAULT verbose true"
-    - "DEFAULT vncserver_proxyclient_address {{ internal_ipaddr }}"
-    - "DEFAULT vncserver_listen {{ internal_ipaddr }}"
-    - "DEFAULT novncproxy_host {{ internal_ipaddr }}"
-    - "DEFAULT novncproxy_base_url http://{{ nova_public_vip }}:6080/vnc_auto.html"
-    - "DEFAULT novncproxy_host {{ internal_ipaddr}}"
-    - "database connection mysql://nova:{{ nova_db_pass }}@{{ lb_db_vip }}/nova"
-    - "database max_retries -1"
-    - "DEFAULT auth_strategy keystone"
-    - "DEFAULT memcache_servers {{ memcached_servers }}"
-    - "DEFAULT rabbit_hosts {{ rabbit_hosts }}"
-    - "DEFAULT rabbit_ha_queues true"
-    - "DEFAULT osapi_compute_listen {{ internal_ipaddr }}"
-    - "DEFAULT metadata_host {{ nova_private_vip }}"
-    - "DEFAULT metadata_listen {{ internal_ipaddr }}"
-    - "DEFAULT metadata_listen_port {{ nova_metadata_port }}"
-    - "neutron service_metadata_proxy True"
-    - "neutron metadata_proxy_shared_secret {{ neutron_metadata_proxy_shared_secret }}"
-    - "DEFAULT glance_host {{ glance_private_vip }}"
-    - "DEFAULT glance_port {{ glance_port | default(9292) }}"
-    - "DEFAULT network_api_class nova.network.neutronv2.api.API"
-    - "DEFAULT neutron_url http://{{ neutron_private_vip | default('127.0.0.1') }}:{{ neutron_port | default(9696) }}/"
-    - "DEFAULT neutron_admin_tenant_name services"
-    - "DEFAULT neutron_admin_username neutron"
-    - "DEFAULT neutron_admin_password {{ neutron_pass }}"
-    - "DEFAULT neutron_admin_auth_url http://{{ keystone_private_vip | default('127.0.0.1') }}:{{ keystone_private_port | default(5000) }}/v2.0"
-    - "DEFAULT ovs_bridge br-int"
-    - "DEFAULT auth_strategy keystone"
-    - "DEFAULT firewall_driver nova.virt.firewall.NoopFirewallDriver"
-    - "DEFAULT libvirt_vif_driver nova.virt.libvirt.vif.LibvirtGenericVIFDriver"
-    - "DEFAULT security_group_api {{ nova_security_group_api }}"
-    - "conductor use_local false"
-    - "DEFAULT scheduler_host_subset_size 30"
-    - "DEFAULT notification_topics notifications"
-    - "DEFAULT notification_driver ceilometer.compute.nova_notifier"
-    - "DEFUALT notification_driver nova.openstack.common.notifier.rpc_notifier"
-    - "DEFAULT rpc_backend nova.openstack.common.rpc.impl_kombu"
-  register: cmd
-  changed_when: "'unchanged' not in cmd.stderr"
+    - { section: "DEFAULT", option: "verbose", value: "true" }
+    - { section: "DEFAULT", option: "vncserver_proxyclient_address", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "vncserver_listen", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "novncproxy_host", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "novncproxy_base_url", value: "http://{{ nova_public_vip }}:6080/vnc_auto.html" }
+    - { section: "DEFAULT", option: "novncproxy_host", value: "{{ internal_ipaddr}}" }
+    - { section: "database", option: "connection", value: "mysql://nova:{{ nova_db_pass }}@{{ lb_db_vip }}/nova" }
+    - { section: "database", option: "max_retries", value: "-1" }
+    - { section: "DEFAULT", option: "auth_strategy", value: "keystone" }
+    - { section: "DEFAULT", option: "memcache_servers", value: "{{ memcached_servers }}" }
+    - { section: "DEFAULT", option: "rabbit_hosts", value: "{{ rabbit_hosts }}" }
+    - { section: "DEFAULT", option: "rabbit_ha_queues", value: "true" }
+    - { section: "DEFAULT", option: "osapi_compute_listen", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "metadata_host", value: "{{ nova_private_vip }}" }
+    - { section: "DEFAULT", option: "metadata_listen", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "metadata_listen_port", value: "{{ nova_metadata_port }}" }
+    - { section: "neutron", option: "service_metadata_proxy", value: "True" }
+    - { section: "neutron", option: "metadata_proxy_shared_secret", value: "{{ neutron_metadata_proxy_shared_secret }}" }
+    - { section: "DEFAULT", option: "glance_host", value: "{{ glance_private_vip }}" }
+    - { section: "DEFAULT", option: "glance_port", value: "{{ glance_port | default(9292) }}" }
+    - { section: "DEFAULT", option: "network_api_class", value: "nova.network.neutronv2.api.API" }
+    - { section: "DEFAULT", option: "neutron_url", value: "http://{{ neutron_private_vip | default('127.0.0.1') }}:{{ neutron_port | default(9696) }}/" }
+    - { section: "DEFAULT", option: "neutron_admin_tenant_name", value: "services" }
+    - { section: "DEFAULT", option: "neutron_admin_username", value: "neutron" }
+    - { section: "DEFAULT", option: "neutron_admin_password", value: "{{ neutron_pass }}" }
+    - { section: "DEFAULT", option: "neutron_admin_auth_url", value: "http://{{ keystone_private_vip | default('127.0.0.1') }}:{{ keystone_private_port | default(5000) }}/v2.0" }
+    - { section: "DEFAULT", option: "ovs_bridge", value: "br-int" }
+    - { section: "DEFAULT", option: "auth_strategy", value: "keystone" }
+    - { section: "DEFAULT", option: "firewall_driver", value: "nova.virt.firewall.NoopFirewallDriver" }
+    - { section: "DEFAULT", option: "libvirt_vif_driver", value: "nova.virt.libvirt.vif.LibvirtGenericVIFDriver" }
+    - { section: "DEFAULT", option: "security_group_api", value: "{{ nova_security_group_api }}" }
+    - { section: "conductor", option: "use_local", value: "false" }
+    - { section: "DEFAULT", option: "scheduler_host_subset_size", value: "30" }
+    - { section: "DEFAULT", option: "notification_topics", value: "notifications" }
+    - { section: "DEFAULT", option: "notification_driver", value: "ceilometer.compute.nova_notifier" }
+    - { section: "DEFUALT", option: "notification_driver", value: "nova.openstack.common.notifier.rpc_notifier" }
+    - { section: "DEFAULT", option: "rpc_backend", value: "nova.openstack.common.rpc.impl_kombu" }
   tags: nova
 
 - name: add novnc vip /etc/hosts with all nodes

--- a/roles/nova-control/tasks/kilo.yml
+++ b/roles/nova-control/tasks/kilo.yml
@@ -27,47 +27,50 @@
   tags: nova
 
 - name: Update nova.conf file
-  command: openstack-config --verbose --set /etc/nova/nova.conf {{ item }}
+  ini_file:
+    dest: /etc/nova/nova.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
   with_items:
-    - "DEFAULT verbose true"
-    - "DEFAULT vncserver_proxyclient_address {{ internal_ipaddr }}"
-    - "DEFAULT vncserver_listen {{ internal_ipaddr }}"
-    - "DEFAULT novncproxy_host {{ internal_ipaddr }}"
-    - "DEFAULT novncproxy_base_url http://{{ nova_public_vip }}:6080/vnc_auto.html"
-    - "DEFAULT novncproxy_host {{ internal_ipaddr}}"
-    - "database connection mysql://nova:{{ nova_db_pass }}@{{ lb_db_vip }}/nova"
-    - "database max_retries -1"
-    - "DEFAULT auth_strategy keystone"
-    - "DEFAULT memcache_servers {{ memcached_servers }}"
-    - "DEFAULT rabbit_hosts {{ rabbit_hosts }}"
-    - "DEFAULT rabbit_ha_queues true"
-    - "DEFAULT osapi_compute_listen {{ internal_ipaddr }}"
-    - "DEFAULT metadata_host {{ nova_private_vip }}"
-    - "DEFAULT metadata_listen {{ internal_ipaddr }}"
-    - "DEFAULT metadata_listen_port {{ nova_metadata_port }}"
-    - "neutron service_metadata_proxy True"
-    - "neutron metadata_proxy_shared_secret {{ neutron_metadata_proxy_shared_secret }}"
-    - "DEFAULT glance_host {{ glance_private_vip }}"
-    - "DEFAULT glance_port {{ glance_port | default(9292) }}"
-    - "DEFAULT network_api_class nova.network.neutronv2.api.API"
-    - "DEFAULT neutron_url http://{{ neutron_private_vip | default('127.0.0.1') }}:{{ neutron_port | default(9696) }}/"
-    - "DEFAULT neutron_admin_tenant_name services"
-    - "DEFAULT neutron_admin_username neutron"
-    - "DEFAULT neutron_admin_password {{ neutron_pass }}"
-    - "DEFAULT neutron_admin_auth_url http://{{ keystone_private_vip | default('127.0.0.1') }}:{{ keystone_private_port | default(5000) }}/v2.0"
-    - "DEFAULT ovs_bridge br-int"
-    - "DEFAULT auth_strategy keystone"
-    - "DEFAULT firewall_driver nova.virt.firewall.NoopFirewallDriver"
-    - "DEFAULT libvirt_vif_driver nova.virt.libvirt.vif.LibvirtGenericVIFDriver"
-    - "DEFAULT security_group_api {{ nova_security_group_api }}"
-    - "conductor use_local false"
-    - "DEFAULT scheduler_host_subset_size 30"
-    - "DEFAULT notification_topics notifications"
-    - "DEFAULT notification_driver ceilometer.compute.nova_notifier"
-    - "DEFUALT notification_driver nova.openstack.common.notifier.rpc_notifier"
-    - "DEFAULT rpc_backend nova.openstack.common.rpc.impl_kombu"
-  register: cmd
-  changed_when: "'unchanged' not in cmd.stderr"
+    - { section: "DEFAULT", option: "verbose", value: "true" }
+    - { section: "DEFAULT", option: "vncserver_proxyclient_address", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "vncserver_listen", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "novncproxy_host", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "novncproxy_base_url", value: "http://{{ nova_public_vip }}:6080/vnc_auto.html" }
+    - { section: "DEFAULT", option: "novncproxy_host", value: "{{ internal_ipaddr}}" }
+    - { section: "database", option: "connection", value: "mysql://nova:{{ nova_db_pass }}@{{ lb_db_vip }}/nova" }
+    - { section: "database", option: "max_retries", value: "-1" }
+    - { section: "DEFAULT", option: "auth_strategy", value: "keystone" }
+    - { section: "DEFAULT", option: "memcache_servers", value: "{{ memcached_servers }}" }
+    - { section: "DEFAULT", option: "rabbit_hosts", value: "{{ rabbit_hosts }}" }
+    - { section: "DEFAULT", option: "rabbit_ha_queues", value: "true" }
+    - { section: "DEFAULT", option: "osapi_compute_listen", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "metadata_host", value: "{{ nova_private_vip }}" }
+    - { section: "DEFAULT", option: "metadata_listen", value: "{{ internal_ipaddr }}" }
+    - { section: "DEFAULT", option: "metadata_listen_port", value: "{{ nova_metadata_port }}" }
+    - { section: "neutron", option: "service_metadata_proxy", value: "True" }
+    - { section: "neutron", option: "metadata_proxy_shared_secret", value: "{{ neutron_metadata_proxy_shared_secret }}" }
+    - { section: "DEFAULT", option: "glance_host", value: "{{ glance_private_vip }}" }
+    - { section: "DEFAULT", option: "glance_port", value: "{{ glance_port | default(9292) }}" }
+    - { section: "DEFAULT", option: "network_api_class", value: "nova.network.neutronv2.api.API" }
+    - { section: "DEFAULT", option: "neutron_url", value: "http://{{ neutron_private_vip | default('127.0.0.1') }}:{{ neutron_port | default(9696) }}/" }
+    - { section: "DEFAULT", option: "neutron_admin_tenant_name", value: "services" }
+    - { section: "DEFAULT", option: "neutron_admin_username", value: "neutron" }
+    - { section: "DEFAULT", option: "neutron_admin_password", value: "{{ neutron_pass }}" }
+    - { section: "DEFAULT", option: "neutron_admin_auth_url", value: "http://{{ keystone_private_vip | default('127.0.0.1') }}:{{ keystone_private_port | default(5000) }}/v2.0" }
+    - { section: "DEFAULT", option: "ovs_bridge", value: "br-int" }
+    - { section: "DEFAULT", option: "auth_strategy", value: "keystone" }
+    - { section: "DEFAULT", option: "firewall_driver", value: "nova.virt.firewall.NoopFirewallDriver" }
+    - { section: "DEFAULT", option: "libvirt_vif_driver", value: "nova.virt.libvirt.vif.LibvirtGenericVIFDriver" }
+    - { section: "DEFAULT", option: "security_group_api", value: "{{ nova_security_group_api }}" }
+    - { section: "conductor", option: "use_local", value: "false" }
+    - { section: "DEFAULT", option: "scheduler_host_subset_size", value: "30" }
+    - { section: "DEFAULT", option: "notification_topics", value: "notifications" }
+    - { section: "DEFAULT", option: "notification_driver", value: "ceilometer.compute.nova_notifier" }
+    - { section: "DEFUALT", option: "notification_driver", value: "nova.openstack.common.notifier.rpc_notifier" }
+    - { section: "DEFAULT", option: "rpc_backend", value: "nova.openstack.common.rpc.impl_kombu" }
+  tags: nova
   tags: nova
 
 - name: add novnc vip /etc/hosts with all nodes

--- a/roles/nova-control/tasks/kilo.yml
+++ b/roles/nova-control/tasks/kilo.yml
@@ -71,7 +71,6 @@
     - { section: "DEFUALT", option: "notification_driver", value: "nova.openstack.common.notifier.rpc_notifier" }
     - { section: "DEFAULT", option: "rpc_backend", value: "nova.openstack.common.rpc.impl_kombu" }
   tags: nova
-  tags: nova
 
 - name: add novnc vip /etc/hosts with all nodes
   tags: nova


### PR DESCRIPTION
Removal of openstack-config and replaced with ini_file ansible module

```
ASK: [nova-control | Update nova.conf file] **********************************
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'verbose', 'value': 'true'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'verbose', 'value': 'true'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'verbose', 'value': 'true'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'vncserver_proxyclient_address', 'value': u'172.17.17.71'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'vncserver_proxyclient_address', 'value': u'172.17.17.72'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'vncserver_listen', 'value': u'172.17.17.71'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'vncserver_listen', 'value': u'172.17.17.72'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'vncserver_proxyclient_address', 'value': u'172.17.17.70'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'novncproxy_host', 'value': u'172.17.17.71'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'novncproxy_host', 'value': u'172.17.17.72'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'novncproxy_base_url', 'value': u'http://172.17.17.117:6080/vnc_auto.html'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'novncproxy_base_url', 'value': u'http://172.17.17.117:6080/vnc_auto.html'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'vncserver_listen', 'value': u'172.17.17.70'})
ok: [controller-2] => (item={'section': 'DEFAULT', 'option': 'novncproxy_host', 'value': u'172.17.17.71'})
ok: [controller-3] => (item={'section': 'DEFAULT', 'option': 'novncproxy_host', 'value': u'172.17.17.72'})
changed: [controller-2] => (item={'section': 'database', 'option': 'connection', 'value': u'mysql://nova:QjjE0HzOIii5aP1IbQ1C@172.17.17.101/nova'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'novncproxy_host', 'value': u'172.17.17.70'})
changed: [controller-3] => (item={'section': 'database', 'option': 'connection', 'value': u'mysql://nova:QjjE0HzOIii5aP1IbQ1C@172.17.17.101/nova'})
changed: [controller-2] => (item={'section': 'database', 'option': 'max_retries', 'value': '-1'})
changed: [controller-3] => (item={'section': 'database', 'option': 'max_retries', 'value': '-1'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'novncproxy_base_url', 'value': u'http://172.17.17.117:6080/vnc_auto.html'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'auth_strategy', 'value': 'keystone'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'auth_strategy', 'value': 'keystone'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'memcache_servers', 'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'memcache_servers', 'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
ok: [controller-1] => (item={'section': 'DEFAULT', 'option': 'novncproxy_host', 'value': u'172.17.17.70'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'rabbit_hosts', 'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'rabbit_hosts', 'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'rabbit_ha_queues', 'value': 'true'})
changed: [controller-1] => (item={'section': 'database', 'option': 'connection', 'value': u'mysql://nova:QjjE0HzOIii5aP1IbQ1C@172.17.17.101/nova'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'rabbit_ha_queues', 'value': 'true'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'osapi_compute_listen', 'value': u'172.17.17.71'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'osapi_compute_listen', 'value': u'172.17.17.72'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'metadata_host', 'value': u'172.17.17.106'})
changed: [controller-1] => (item={'section': 'database', 'option': 'max_retries', 'value': '-1'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'metadata_host', 'value': u'172.17.17.106'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'metadata_listen', 'value': u'172.17.17.71'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'metadata_listen', 'value': u'172.17.17.72'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'auth_strategy', 'value': 'keystone'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'metadata_listen_port', 'value': u'8775'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'metadata_listen_port', 'value': u'8775'})
changed: [controller-2] => (item={'section': 'neutron', 'option': 'service_metadata_proxy', 'value': 'True'})
changed: [controller-3] => (item={'section': 'neutron', 'option': 'service_metadata_proxy', 'value': 'True'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'memcache_servers', 'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
changed: [controller-2] => (item={'section': 'neutron', 'option': 'metadata_proxy_shared_secret', 'value': u'D8EfD51E7C410F741eeB'})
changed: [controller-3] => (item={'section': 'neutron', 'option': 'metadata_proxy_shared_secret', 'value': u'D8EfD51E7C410F741eeB'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'glance_host', 'value': u'172.17.17.104'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'glance_host', 'value': u'172.17.17.104'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'rabbit_hosts', 'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'glance_port', 'value': u'9292'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'glance_port', 'value': u'9292'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'network_api_class', 'value': 'nova.network.neutronv2.api.API'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'rabbit_ha_queues', 'value': 'true'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'network_api_class', 'value': 'nova.network.neutronv2.api.API'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'neutron_url', 'value': u'http://172.17.17.107:9696/'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'neutron_url', 'value': u'http://172.17.17.107:9696/'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_tenant_name', 'value': 'services'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'osapi_compute_listen', 'value': u'172.17.17.70'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_tenant_name', 'value': 'services'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_username', 'value': 'neutron'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_username', 'value': 'neutron'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'metadata_host', 'value': u'172.17.17.106'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_password', 'value': u'qfEvx20tk3JP4pIR5eVx'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_password', 'value': u'qfEvx20tk3JP4pIR5eVx'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_auth_url', 'value': u'http://172.17.17.103:5000/v2.0'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_auth_url', 'value': u'http://172.17.17.103:5000/v2.0'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'metadata_listen', 'value': u'172.17.17.70'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'ovs_bridge', 'value': 'br-int'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'ovs_bridge', 'value': 'br-int'})
ok: [controller-2] => (item={'section': 'DEFAULT', 'option': 'auth_strategy', 'value': 'keystone'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'metadata_listen_port', 'value': u'8775'})
ok: [controller-3] => (item={'section': 'DEFAULT', 'option': 'auth_strategy', 'value': 'keystone'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'firewall_driver', 'value': 'nova.virt.firewall.NoopFirewallDriver'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'firewall_driver', 'value': 'nova.virt.firewall.NoopFirewallDriver'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'libvirt_vif_driver', 'value': 'nova.virt.libvirt.vif.LibvirtGenericVIFDriver'})
changed: [controller-1] => (item={'section': 'neutron', 'option': 'service_metadata_proxy', 'value': 'True'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'libvirt_vif_driver', 'value': 'nova.virt.libvirt.vif.LibvirtGenericVIFDriver'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'security_group_api', 'value': u'neutron'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'security_group_api', 'value': u'neutron'})
changed: [controller-2] => (item={'section': 'conductor', 'option': 'use_local', 'value': 'false'})
changed: [controller-1] => (item={'section': 'neutron', 'option': 'metadata_proxy_shared_secret', 'value': u'D8EfD51E7C410F741eeB'})
changed: [controller-3] => (item={'section': 'conductor', 'option': 'use_local', 'value': 'false'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'scheduler_host_subset_size', 'value': '30'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'glance_host', 'value': u'172.17.17.104'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'scheduler_host_subset_size', 'value': '30'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'notification_topics', 'value': 'notifications'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'notification_topics', 'value': 'notifications'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'notification_driver', 'value': 'ceilometer.compute.nova_notifier'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'glance_port', 'value': u'9292'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'notification_driver', 'value': 'ceilometer.compute.nova_notifier'})
changed: [controller-2] => (item={'section': 'DEFUALT', 'option': 'notification_driver', 'value': 'nova.openstack.common.notifier.rpc_notifier'})
changed: [controller-3] => (item={'section': 'DEFUALT', 'option': 'notification_driver', 'value': 'nova.openstack.common.notifier.rpc_notifier'})
changed: [controller-2] => (item={'section': 'DEFAULT', 'option': 'rpc_backend', 'value': 'nova.openstack.common.rpc.impl_kombu'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'network_api_class', 'value': 'nova.network.neutronv2.api.API'})
changed: [controller-3] => (item={'section': 'DEFAULT', 'option': 'rpc_backend', 'value': 'nova.openstack.common.rpc.impl_kombu'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'neutron_url', 'value': u'http://172.17.17.107:9696/'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_tenant_name', 'value': 'services'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_username', 'value': 'neutron'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_password', 'value': u'qfEvx20tk3JP4pIR5eVx'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_auth_url', 'value': u'http://172.17.17.103:5000/v2.0'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'ovs_bridge', 'value': 'br-int'})
ok: [controller-1] => (item={'section': 'DEFAULT', 'option': 'auth_strategy', 'value': 'keystone'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'firewall_driver', 'value': 'nova.virt.firewall.NoopFirewallDriver'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'libvirt_vif_driver', 'value': 'nova.virt.libvirt.vif.LibvirtGenericVIFDriver'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'security_group_api', 'value': u'neutron'})
changed: [controller-1] => (item={'section': 'conductor', 'option': 'use_local', 'value': 'false'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'scheduler_host_subset_size', 'value': '30'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'notification_topics', 'value': 'notifications'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'notification_driver', 'value': 'ceilometer.compute.nova_notifier'})
changed: [controller-1] => (item={'section': 'DEFUALT', 'option': 'notification_driver', 'value': 'nova.openstack.common.notifier.rpc_notifier'})
changed: [controller-1] => (item={'section': 'DEFAULT', 'option': 'rpc_backend', 'value': 'nova.openstack.common.rpc.impl_kombu'})


TASK: [nova-compute | Update nova config file] ********************************
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'verbose', 'value': 'true'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'memcached_servers', 'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'rabbit_hosts', 'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'rabbit_ha_queues', 'value': 'true'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'heat_metadata_server_url', 'value': u'{# heat_metadata_server_url #}'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'heat_waitcondition_server_url', 'value': u'{# heat_waitcondition_server_url #}'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'heat_watch_server_url', 'value': u'{# heat_watch_server_url #}'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'rpc_backend', 'value': 'heat.openstack.common.rpc.impl_kombu'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'notification_driver', 'value': 'heat.openstack.common.notifier.rpc_notifier'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'vif_plugging_is_fatal', 'value': 'False'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'vif_plugging_timeout', 'value': '0'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'vncserver_proxyclient_address', 'value': u'172.17.17.73'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'vncserver_listen', 'value': '0.0.0.0'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'novncproxy_base_url', 'value': u'http://172.17.17.117:6080/vnc_auto.html'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'auth_startegy', 'value': 'keystone'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'metadata_host', 'value': u'172.17.17.106'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'metadata_listen', 'value': u'172.17.17.73'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'metadata_listen_port', 'value': u'8775'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'glance_host', 'value': u'172.17.17.104'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'glance_port', 'value': u'9292'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'network_api_class', 'value': 'nova.network.neutronv2.api.API'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'neutron_url', 'value': u'http://172.17.17.107:9696/'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_tenant_name', 'value': 'services'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_username', 'value': 'neutron'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_password', 'value': u'qfEvx20tk3JP4pIR5eVx'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'neutron_admin_auth_url ', 'value': u'http://172.17.17.103:5000/v2.0'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'ovs_bridge', 'value': 'br-int'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'firewall_driver', 'value': 'nova.virt.firewall.NoopFirewallDriver'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'libvirt_vif_driver', 'value': 'nova.virt.libvirt.vif.LibvirtGenericVIFDriver'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'security_group_api', 'value': u'neutron'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'scheduler_host_subset_size', 'value': '30'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'instance_usage_audit', 'value': 'True'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'instance_usage_audit_period', 'value': 'hour'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'notify_on_state_change', 'value': 'vm_and_task_state'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'notification_topics', 'value': 'notifications'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'notification_driver', 'value': 'nova.openstack.common.notifier.rpc_notifier'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'rpc_backend', 'value': 'nova.openstack.common.rpc.impl_kombu'})
ok: [compute-1] => (item={'section': 'DEFAULT', 'option': 'instance_usage_audit', 'value': 'True'})
ok: [compute-1] => (item={'section': 'DEFAULT', 'option': 'notify_on_state_change', 'value': 'vm_and_task_state'})
changed: [compute-1] => (item={'section': 'neutron', 'option': 'service_neutron_metadata_proxy', 'value': 'True'})
changed: [compute-1] => (item={'section': 'neutron', 'option': 'neutron_metadata_proxy_shared_secret', 'value': u'D8EfD51E7C410F741eeB'})
changed: [compute-1] => (item={'section': 'conductor', 'option': 'use_local', 'value': 'False'})
changed: [compute-1] => (item={'section': 'database', 'option': 'connection', 'value': u'mysql://nova:QjjE0HzOIii5aP1IbQ1C@172.17.17.101/nova'})
changed: [compute-1] => (item={'section': 'database', 'option': 'max_retries', 'value': '-1'})

TASK: [nova-compute | Update ceilometer.conf file] ****************************
ok: [compute-1] => (item={'section': 'DEFAULT', 'option': 'verbose', 'value': 'true'})
ok: [compute-1] => (item={'section': 'DEFAULT', 'option': 'memcached_servers', 'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
changed: [compute-1] => (item={'section': 'DEFAULT', 'option': 'rabbit_hosts', 'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
ok: [compute-1] => (item={'section': 'DEFAULT', 'option': 'rabbit_ha_queues', 'value': 'true'})
ok: [compute-1] => (item={'section': 'keystone_authtoken', 'option': 'auth_host', 'value': u'127.0.0.1'})
ok: [compute-1] => (item={'section': 'keystone_authtoken', 'option': 'auth_port', 'value': u'35357'})
ok: [compute-1] => (item={'section': 'keystone_authtoken', 'option': 'auth_protocol', 'value': u'http'})
changed: [compute-1] => (item={'section': 'keystone_authtoken', 'option': 'auth_uri', 'value': u"{# keystone_auth_protocol | default('http') #}://{# keystone_admin_vip #}:{# keystone_auth_port | default (35357) #}/v2.0"})
ok: [compute-1] => (item={'section': 'keystone_authtoken', 'option': 'admin_tenant_name', 'value': 'services'})
ok: [compute-1] => (item={'section': 'keystone_authtoken', 'option': 'admin_user', 'value': 'ceilometer'})
ok: [compute-1] => (item={'section': 'keystone_authtoken', 'option': 'admin_password', 'value': u'UINJ9P8P4ha3JntVK5Eo'})
ok: [compute-1] => (item={'section': 'database', 'option': 'connection', 'value': u'mongodb://controller-1:27017,controller-2:27017,controller-3:27017/ceilometer?replicaSet=ceilometer'})
ok: [compute-1] => (item={'section': 'database', 'option': 'max_retries', 'value': '-1'})
changed: [compute-1] => (item={'section': 'database', 'option': 'time_to_live', 'value': u'44320'})
changed: [compute-1] => (item={'section': 'service_credentials', 'option': 'os_auth_url', 'value': u"{# keystone_auth_protocol | default('http') #}://{# keystone_private_vip #}:{# keystone_private_port | default (5000) #}/v2.0"})
ok: [compute-1] => (item={'section': 'service_credentials', 'option': 'os_username', 'value': 'ceilometer'})
ok: [compute-1] => (item={'section': 'service_credentials', 'option': 'os_password', 'value': u'UINJ9P8P4ha3JntVK5Eo'})
changed: [compute-1] => (item={'section': 'service_credentials', 'option': 'os_tenant_name', 'value': 'services'})
changed: [compute-1] => (item={'section': 'publisher_rpc', 'option': 'metering_secret', 'value': u'30ae0aae816CDB6F7e6D'})
```

Run failed due to missing package in for demo role.
