### PR TITLE
added conditional for swift not to run iface if its has controller on…

### DIFF
--- a/swift.yml
+++ b/swift.yml
@@ -73,6 +73,7 @@
    #     onboot: '"yes"'
    #     ipaddr: "{{ swift_if.ipaddr}}"
    #     netmask: "{{ swift_if.ipaddr}}"
+   #   when: "'controller' not in group_names"
 
 - name: Controller Swift Proxy 1
   hosts: controller

--- a/swift.yml
+++ b/swift.yml
@@ -12,6 +12,7 @@
         peerdns: '"no"'
         master: bond0
         slave: '"yes"'
+      when: "'controller' not in group_names"
 
     - role: iface
       device: "{{bond_device[1]}}"
@@ -22,6 +23,7 @@
         peerdns: '"no"'
         master: bond0
         slave: '"yes"'
+      when: "'controller' not in group_names"
 
     - role: iface
       device: bond0
@@ -31,6 +33,7 @@
         bonding_opts: '"miimon=100 mode=802.3ad"'
         onboot: '"yes"'
         peerdns: '"no"'
+      when: "'controller' not in group_names"
 
     - role: iface
       device: "bond0.{{ int_if.vlan }}"
@@ -45,6 +48,7 @@
         defroute: "yes"
         onboot: '"yes"'
         peerdns: '"no"'
+      when: "'controller' not in group_names"
 
     - role: iface
       device: "bond0.{{ storage_if.vlan }}"
@@ -57,6 +61,7 @@
         netmask: "{{ storage_if.netmask }}"
         onboot: '"yes"'
         peerdns: '"no"'
+      when: "'controller' not in group_names"
 
    # - role: iface
    #   device: "bond0.{{ swift_if.vlan }}"


### PR DESCRIPTION
PLAY [Swift Interface Configuration] ******************************************

GATHERING FACTS ***************************************************************
ok: [controller-3]
ok: [controller-2]
ok: [controller-1]

TASK: [iface | deploy network interface config file] **************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | bring up deployed interface] ***********************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | deploy network interface config file] **************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | bring up deployed interface] ***********************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | deploy network interface config file] **************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | bring up deployed interface] ***********************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | deploy network interface config file] **************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | bring up deployed interface] ***********************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | deploy network interface config file] **************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]

TASK: [iface | bring up deployed interface] ***********************************
skipping: [controller-1]
skipping: [controller-2]
skipping: [controller-3]
