### PR TITLE
Updating role defaults

### DIFF
--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -1,1 +1,2 @@
-haproxy_admin_pass: "{{ site_password }}"
+haproxy_admin_pass:  "{{ lookup('password', credentials_dir + '/credentials/haproxy_pass chars=ascii_letters,digits') }}"
+credentials_dir: /var/lib/ansible


### PR DESCRIPTION
Removing site_password from defaults as this is the only place in the project the variable is used.  Implementing standard password lookup method.

This is to support the disentanglement from the Wiley Inventory.

The code used here is the same tested code which was submitted to Benny for the haproxy role.
