### PR TITLE
Fixed issues with Galera nodes in haproxy.

### DIFF
--- a/roles/haproxy/templates/juno.haproxy.cfg.j2
+++ b/roles/haproxy/templates/juno.haproxy.cfg.j2
@@ -24,9 +24,9 @@ backend db-galera
     option httpchk
     stick-table type ip size 2
     stick on dst
-    timeout server 90m
+    timeout server 90s
 {% for node in groups['controller'] %}
-    server {{ hostvars[node]['ansible_hostname'] }} {{ hostvars[node]['ansible_' + private_if ]['ipv4']['address'] }}:3306 check inter 1s port 9200 
+    server {{ hostvars[node]['ansible_hostname'] }} {{ hostvars[node]['ansible_' + private_if ]['ipv4']['address'] }}:3306 check inter 1s port 9200 on-marked-down shutdown-sessions
 {% endfor %}
 
 

--- a/roles/haproxy/templates/kilo.haproxy.cfg.j2
+++ b/roles/haproxy/templates/kilo.haproxy.cfg.j2
@@ -22,9 +22,9 @@ frontend vip-db
 
 backend db-galera
     option httpchk
-    stick-table type ip size 1000
+    stick-table type ip size 2
     stick on dst
-    timeout server 90m
+    timeout server 90s
 {% for node in groups['controller'] %}
     server {{ hostvars[node]['ansible_hostname'] }} {{ hostvars[node]['ansible_' + private_if ]['ipv4']['address'] }}:3306 check inter 1s port 9200 backup on-mark-down shutdown-sessions
 {% endfor %}


### PR DESCRIPTION
This PR should fix issues with Deadlocks. 

```
2015-11-30 14:57:56.283 114768 TRACE neutron.agent.l3_agent [u'Traceback (most recent call last):\n', u'  File "/usr/lib/python2.7/site-packages/oslo/messaging/rpc/dispatcher.py", line 134, in _dispatch_and_reply\n    incoming.message))\n', u'  File "/usr/lib/python2.7/site-packages/oslo/messaging/rpc/dispatcher.py", line 177, in _dispatch\n    return self._do_dispatch(endpoint, method, ctxt, args)\n', u'  File "/usr/lib/python2.7/site-packages/oslo/messaging/rpc/dispatcher.py", line 123, in _do_dispatch\n    result = getattr(endpoint, method)(ctxt, **new_args)\n', u'  File "/usr/lib/python2.7/site-packages/neutron/api/rpc/handlers/l3_rpc.py", line 83, in sync_routers\n    self._ensure_host_set_on_ports(context, host, routers)\n', u'  File "/usr/lib/python2.7/site-packages/neutron/api/rpc/handlers/l3_rpc.py", line 104, in _ensure_host_set_on_ports\n    router[\'id\'])\n', u'  File "/usr/lib/python2.7/site-packages/neutron/api/rpc/handlers/l3_rpc.py", line 124, in _ensure_host_set_on_port\n    {\'port\': {portbindings.HOST_ID: host}})\n', u'  File "/usr/lib/python2.7/site-packages/neutron/plugins/ml2/plugin.py", line 901, in update_port\n    need_notify=need_port_update_notify)\n', u'  File "/usr/lib/python2.7/site-packages/neutron/plugins/ml2/plugin.py", line 278, in _bind_port_if_needed\n    plugin_context, port_id, binding, bind_context)\n', u'  File "/usr/lib/python2.7/site-packages/neutron/plugins/ml2/plugin.py", line 374, in _commit_port_binding\n    self.mechanism_manager.update_port_precommit(cur_context)\n', u'  File "/usr/lib64/python2.7/contextlib.py", line 24, in __exit__\n    self.gen.next()\n', u'  File "/usr/lib64/python2.7/contextlib.py", line 121, in nested\n    if exit(*exc):\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/orm/session.py", line 470, in __exit__\n    self.rollback()\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/util/langhelpers.py", line 60, in __exit__\n    compat.reraise(exc_type, exc_value, exc_tb)\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/orm/session.py", line 467, in __exit__\n    self.commit()\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/orm/session.py", line 381, in commit\n    t[1].commit()\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/base.py", line 1333, in commit\n    self._do_commit()\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/base.py", line 1364, in _do_commit\n    self.connection._commit_impl()\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/base.py", line 527, in _commit_impl\n    self._handle_dbapi_exception(e, None, None, None, None)\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/base.py", line 1155, in _handle_dbapi_exception\n    util.raise_from_cause(newraise, exc_info)\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/util/compat.py", line 199, in raise_from_cause\n    reraise(type(exception), exception, tb=exc_tb)\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/engine/base.py", line 525, in _commit_impl\n    self.engine.dialect.do_commit(self.connection)\n', u'  File "/usr/lib64/python2.7/site-packages/sqlalchemy/dialects/mysql/base.py", line 2342, in do_commit\n    dbapi_connection.commit()\n', u"DBDeadlock: (OperationalError) (1213, 'Deadlock found when trying to get lock; try restarting transaction') None None\n"].
```
