### PR TITLE
removed errant debug output.

### DIFF
--- a/roles/pacemaker/tasks/main.yml
+++ b/roles/pacemaker/tasks/main.yml
@@ -43,8 +43,6 @@
   service: name=pcsd enabled=yes state=started
   tags: pcs
 
-- debug: msg="{{cluster_nodes}}"
-
 - name: set pcs cluster auth
   command: pcs cluster auth -u hacluster -p {{ pcs_cluster_pass }} {{ cluster_nodes }} --force
   when: "'Already authorized' not in cmd.stdout"


### PR DESCRIPTION
Removed debug statement from Pacemaker role.

```
TASK: [pacemaker | debug msg="{% for node in groups['controller'] %} {{hostvars[node]['ansible_hostname']}} {% endfor %}"] ***
ok: [controller-2] => {
    "msg": " controller-1  controller-2  controller-3 "
}
ok: [controller-1] => {
    "msg": " controller-1  controller-2  controller-3 "
}
ok: [controller-3] => {
    "msg": " controller-1  controller-2  controller-3 "
}
```
