### PR TITLE
Adding Reverse Path Filter Kernel Config

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -7,6 +7,15 @@
   command: sysctl -p /etc/sysctl.d/99-sysctl.conf
   tags: sysctl
 
+- name: Set default rp_filter
+  sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+  with_items: 
+    - { name: net.ipv4.conf.default.rp_filter, value: 2 }
+    - { name: net.ipv4.conf.all.rp_filter, value: 2 }
+
 - name: deploy resolv.conf
   template: src=resolv.conf.j2 dest=/etc/resolv.conf
   tags: dns


### PR DESCRIPTION
Added into the common role to configure the net.ipv4.conf.all.rp_filter
and net.ipv4.conf.default.rp_filter values.  Testing will follow.
