### PR TITLE
Correcting group for creating hosts files

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -34,7 +34,7 @@
     line: '{{ hostvars[item].int_if.ipaddr }} {{item}}'
     state: present
   when: hostvars[item].int_if.ipaddr is defined
-  with_items: "{{ groups['openstack'] }}"
+  with_items: "{{ groups['all'] }}"
 
 - include: "RedHat-rpms.yml"
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
Hosts files should include ScaleIO nodes as well.

Testing of ScaleIO install which failed after the last change to slimer:

```
PLAY RECAP *********************************************************************
compute-1                  : ok=14   changed=7    unreachable=0    failed=0
controller-1               : ok=30   changed=16   unreachable=0    failed=0
controller-2               : ok=29   changed=18   unreachable=0    failed=0
controller-3               : ok=27   changed=16   unreachable=0    failed=0
scaleio-1                  : ok=31   changed=16   unreachable=0    failed=0
scaleio-2                  : ok=22   changed=9    unreachable=0    failed=0
scaleio-3                  : ok=26   changed=12   unreachable=0    failed=0
```
