### PR TITLE
removal of duplicated and raw variables.

### DIFF
--- a/roles/haproxy/tasks/juno.yml
+++ b/roles/haproxy/tasks/juno.yml
@@ -34,7 +34,7 @@
   args:
     options:
       ip: "{{ item.addr }}"
-  with_items: vip_addresses
+  with_items: "{{vip_addresses}}"
   run_once: true
   tags: haproxy
 

--- a/roles/neutron/defaults/main.yml
+++ b/roles/neutron/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 ### Neutron parameters
-neutron_core_plugin: neutron.plugins.ml2.plugin.Ml2Plugin
 neutron_service_plugins:
   - neutron.services.l3_router.l3_router_plugin.L3RouterPlugin
   - neutron.services.firewall.fwaas_plugin.FirewallPlugin

--- a/roles/neutron/tasks/juno.yml
+++ b/roles/neutron/tasks/juno.yml
@@ -260,13 +260,13 @@
 
 - name: create ovs bridges
   openvswitch_bridge: bridge={{ item.bridge }} state=present
-  with_items: neutron_ovs_bridges
+  with_items: "{{neutron_ovs_bridges}}"
   when: neutron_ovs_bridges is defined
   tags: neutron
 
 - name: configure ovs ports
   openvswitch_port: bridge={{ item.bridge }} port={{ item.port }} state=present
-  with_items: neutron_ovs_bridges
+  with_items: "{{neutron_ovs_bridges}}"
   when: neutron_ovs_bridges is defined
   tags: neutron
 

--- a/roles/nova-compute/defaults/main.yml
+++ b/roles/nova-compute/defaults/main.yml
@@ -25,4 +25,3 @@ neutron_notify_nova_on_port_status_changes: true
 neutron_notify_nova_on_port_data_changes: true
 neutron_core_plugin: ml2
 use_cinder_nfs_volume_driver: false
-use_nova_nfs_backend: false

--- a/roles/nova-compute/tasks/juno.yml
+++ b/roles/nova-compute/tasks/juno.yml
@@ -118,13 +118,13 @@
 
 - name: create ovs bridges
   openvswitch_bridge: bridge={{ item.bridge }} state=present
-  with_items: neutron_ovs_bridges
+  with_items: "{{neutron_ovs_bridges}}"
   when: neutron_ovs_bridges is defined
   tags: nova
 
 - name: configure ovs ports
   openvswitch_port: bridge={{ item.bridge }} port={{ item.port }} state=present
-  with_items: neutron_ovs_bridges
+  with_items: "{{neutron_ovs_bridges}}"
   when: neutron_ovs_bridges is defined
   tags: nova
 

--- a/roles/pacemaker/tasks/main.yml
+++ b/roles/pacemaker/tasks/main.yml
@@ -85,14 +85,14 @@
       lanplus=1
       cipher=1
       op monitor interval=60s
-  with_items: groups['controller']
+  with_items: "{{groups['controller']}}"
   run_once: true
   tags: pcs
   when: use_stonith
 
 - name: create location constraint
   shell: "pcs constraint list --full | grep ipmilan-fence-{{ item }} || pcs constraint location ipmilan-fence-{{item}} avoids {{item}}"
-  with_items: groups['controller']
+  with_items:  "{{groups['controller']}}"
   run_once: true
   tags: pcs
   when: use_stonith

--- a/roles/swift-storage-1/tasks/juno.yml
+++ b/roles/swift-storage-1/tasks/juno.yml
@@ -114,7 +114,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder account.builder add z{{zone_id}}-{{ int_if.ipaddr }}:6202/{{ item }} 100
            chdir=/etc/swift
-  with_items: pdisk
+  with_items: '{{pdisk}}'
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   ignore_errors: yes
   tags: swift
@@ -125,7 +125,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][0]].zone_id }}-{{ hostvars[groups['swift'][0]].int_if.ipaddr }}:6201/{{ item }} 100
            chdir=/etc/swift
-  with_items: pdisk
+  with_items: '{{pdisk}}'
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
@@ -135,7 +135,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][1]].zone_id }}-{{ hostvars[groups['swift'][1]].int_if.ipaddr }}:6201/{{ item }} 100
            chdir=/etc/swift
-  with_items: pdisk
+  with_items:  '{{pdisk}}'
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
@@ -144,7 +144,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder container.builder add z{{ hostvars[groups['swift'][2]].zone_id }}-{{ hostvars[groups['swift'][2]].int_if.ipaddr }}:6201/{{ item }} 100
            chdir=/etc/swift
-  with_items: pdisk
+  with_items:  '{{pdisk}}'
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
@@ -153,7 +153,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][0]].zone_id}}-{{ hostvars[groups['swift'][0]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: pdisk
+  with_items:  '{{pdisk}}'
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
@@ -162,7 +162,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][1]].zone_id}}-{{ hostvars[groups['swift'][1]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: pdisk
+  with_items:  '{{pdisk}}'
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift
@@ -171,7 +171,7 @@
   delegate_to: "{{ groups['controller'][0] }}"
   command: swift-ring-builder object.builder add z{{hostvars[groups['swift'][2]].zone_id}}-{{ hostvars[groups['swift'][2]].int_if.ipaddr }}:6200/{{ item }} 100
            chdir=/etc/swift
-  with_items: pdisk
+  with_items:  '{{pdisk}}'
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   run_once: true
   tags: swift

--- a/roles/swift-storage-1/tasks/swift_node_drive_setup.yml
+++ b/roles/swift-storage-1/tasks/swift_node_drive_setup.yml
@@ -1,34 +1,34 @@
 ---
 - name: labeldisks provided to swift in group_vars/all.swift_data_drive
   command: parted -s /dev/{{ item }} mklabel gpt
-  with_items: pdisk
+  with_items: "{{pdisk}}"
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   tags: swift
 
 - name: create primary partition table on group_vars/all.swift_data_drive
   command: parted -s /dev/{{item}} unit mib mkpart primary 1 100%
-  with_items: pdisk
+  with_items: "{{pdisk}}"
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   tags: swift
 
 
 - name: format drive for swift using xfs
   filesystem: dev=/dev/{{item}}1 force=yes fstype=xfs
-  with_items: pdisk
+  with_items: "{{pdisk}}"
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'  
   tags: swift
 
 
 - name: create mount point
   file: path=/srv/node/{{item}} state=directory owner=swift group=swift
-  with_items: pdisk
+  with_items: "{{pdisk}}"
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   tags: swift
 
 
 - name: mount swift data drive
   mount: state=mounted  passno=0 dump=0 src=/dev/{{item}}1 name=/srv/node/{{item}} fstype=xfs opts=inode64,noatime,nodiratime
-  with_items: pdisk
+  with_items: "{{pdisk}}"
   when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
   tags: swift
 


### PR DESCRIPTION
This PR cleans up duplicated variables in 2 roles, and deprecation warnings caused by raw variables.

Play recap from run.

```
TASK [demo : launch an instance] ***********************************************
changed: [controller-1]

PLAY RECAP *********************************************************************
compute-1                  : ok=71   changed=56   unreachable=0    failed=0
controller-1               : ok=360  changed=300  unreachable=0    failed=0
controller-2               : ok=225  changed=175  unreachable=0    failed=0
controller-3               : ok=225  changed=175  unreachable=0    failed=0
scaleio-1                  : ok=34   changed=29   unreachable=0    failed=0
scaleio-2                  : ok=34   changed=29   unreachable=0    failed=0
scaleio-3                  : ok=34   changed=29   unreachable=0    failed=0

...

TASK [openstack-compute : include] *********************************************
skipping: [compute-1]

PLAY RECAP *********************************************************************
compute-1                  : ok=14   changed=7    unreachable=0    failed=0
controller-1               : ok=30   changed=16   unreachable=0    failed=0
controller-2               : ok=29   changed=18   unreachable=0    failed=0
controller-3               : ok=27   changed=16   unreachable=0    failed=0
scaleio-1                  : ok=31   changed=16   unreachable=0    failed=0
scaleio-2                  : ok=22   changed=9    unreachable=0    failed=0
scaleio-3                  : ok=26   changed=12   unreachable=0    failed=0
```

Grep from log.   Only Depreciation issues are in ScaleIO

```
[root@autodeploy austin-dell-osp-collapsed]# grep DEPRECATION -A1 -B5  ansible.log
2016-02-09 14:34:33,447 p=12718 u=root |  controller-2               : ok=19   changed=6    unreachable=0    failed=0
2016-02-09 14:34:33,447 p=12718 u=root |  controller-3               : ok=19   changed=6    unreachable=0    failed=0
2016-02-09 14:34:33,447 p=12718 u=root |  scaleio-1                  : ok=19   changed=6    unreachable=0    failed=0
2016-02-09 14:34:33,448 p=12718 u=root |  scaleio-2                  : ok=19   changed=6    unreachable=0    failed=0
2016-02-09 14:34:33,448 p=12718 u=root |  scaleio-3                  : ok=19   changed=6    unreachable=0    failed=0
2016-02-09 14:34:35,084 p=17707 u=root |  [DEPRECATION WARNING]: keystone_user is kept for backwards compatibility but usage is discouraged. The module
documentation details page may explain more about this rationale.. This feature will be removed in a future release.
--
2016-02-09 15:15:07,161 p=25090 u=root |  changed: [scaleio-2]
2016-02-09 15:15:07,194 p=25090 u=root |  changed: [scaleio-1]
2016-02-09 15:15:07,252 p=25090 u=root |  TASK [mdm : add primary mdm] ***************************************************
2016-02-09 15:15:07,857 p=25090 u=root |  changed: [scaleio-1]
2016-02-09 15:15:07,864 p=25090 u=root |  TASK [mdm : wait_for mdm available and find the location of the primary mdm] ***
2016-02-09 15:15:07,881 p=25090 u=root |  [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the
 full variable syntax ('{{groups.mdm}}'). This feature will be removed in a future release. Deprecation warnings can be
 disabled by setting deprecation_warnings=False in ansible.cfg.
2016-02-09 15:15:07,890 p=25090 u=root |  [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the
 full variable syntax ('{{groups.tb}}'). This feature will be removed in a future release. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
2016-02-09 15:15:43,591 p=25090 u=root |  ok: [scaleio-1] => (item=scaleio-1)
2016-02-09 15:15:43,601 p=25090 u=root |  failed: [scaleio-1] => (item=scaleio-2) => {"elapsed": 15, "failed": true, "item": "scaleio-2", "msg": "Timeout when waiting for scaleio-2:6611"}
2016-02-09 15:15:43,609 p=25090 u=root |  failed: [scaleio-1] => (item=scaleio-3) => {"elapsed": 15, "failed": true, "item": "scaleio-3", "msg": "Timeout when waiting for scaleio-3:6611"}
2016-02-09 15:15:43,609 p=25090 u=root |  ...ignoring
2016-02-09 15:15:43,618 p=25090 u=root |  [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the
 full variable syntax ('{{mdm.results}}'). This feature will be removed in a future release. Deprecation warnings can
--
2016-02-09 15:15:46,837 p=25090 u=root |  TASK [tb : copy files] *********************************************************
2016-02-09 15:15:47,511 p=25090 u=root |  changed: [scaleio-3] => (item=/opt/autodeploy/projects/ansible-scaleio/files/EMC-ScaleIO-tb-1.32-2451.4.el7.x86_64.rpm)
2016-02-09 15:15:47,517 p=25090 u=root |  TASK [tb : install package] ****************************************************
2016-02-09 15:15:55,786 p=25090 u=root |  changed: [scaleio-3]
2016-02-09 15:15:55,793 p=25090 u=root |  TASK [tb : wait_for mdm available and find the location of the primary mdm] ****
2016-02-09 15:15:55,809 p=25090 u=root |  [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the
 full variable syntax ('{{groups.mdm}}'). This feature will be removed in a future release. Deprecation warnings can be
 disabled by setting deprecation_warnings=False in ansible.cfg.
2016-02-09 15:15:55,819 p=25090 u=root |  [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the
 full variable syntax ('{{groups.tb}}'). This feature will be removed in a future release. Deprecation warnings can be
--
2016-02-09 15:16:44,427 p=25090 u=root |  TASK [sds : find disks] ********************************************************
2016-02-09 15:16:44,638 p=25090 u=root |  ok: [scaleio-1]
2016-02-09 15:16:44,645 p=25090 u=root |  ok: [scaleio-2]
2016-02-09 15:16:44,653 p=25090 u=root |  ok: [scaleio-3]
2016-02-09 15:16:44,660 p=25090 u=root |  TASK [sds : wait_for mdm available and find the location of the primary mdm] ***
2016-02-09 15:16:44,675 p=25090 u=root |  [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the
 full variable syntax ('{{groups.mdm}}'). This feature will be removed in a future release. Deprecation warnings can be
 disabled by setting deprecation_warnings=False in ansible.cfg.
2016-02-09 15:16:44,683 p=25090 u=root |  [DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the
 full variable syntax ('{{groups.tb}}'). This feature will be removed in a future release. Deprecation warnings can be
[root@autodeploy austin-dell-osp-collapsed]#
```

resolving the following depreciation warnings:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{vip_addresses}}'). This feature
will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [controller-1] => (item={u'name': u'vip-db', u'addr': u'172.17.17.101'})
changed: [controller-1] => (item={u'name': u'vip-msg', u'addr': u'172.17.17.100’})

TASK [pacemaker : create stonith resources] ************************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{groups['controller']}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
skipping: [controller-1] => (item=controller-1)
skipping: [controller-1] => (item=controller-2)
skipping: [controller-1] => (item=controller-3)

TASK [pacemaker : create location constraint] **********************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{groups['controller']}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

TASK [neutron : create ovs bridges] ********************************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{neutron_ovs_bridges}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{neutron_ovs_bridges}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{neutron_ovs_bridges}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
ok: [controller-2] => (item={u'bridge': u'br-ex', u'port': u'bond0.1805'})
ok: [controller-3] => (item={u'bridge': u'br-ex', u'port': u'bond0.1805'})
ok: [controller-1] => (item={u'bridge': u'br-ex', u'port': u'bond0.1805'})

TASK [neutron : configure ovs ports] *******************************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{neutron_ovs_bridges}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{neutron_ovs_bridges}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{neutron_ovs_bridges}}'). This
feature will be removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [controller-2] => (item={u'bridge': u'br-ex', u'port': u'bond0.1805’})

TASK [swift-storage-1 : labeldisks provided to swift in group_vars/all.swift_data_drive] ***
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

TASK [swift-storage-1 : create primary partition table on group_vars/all.swift_data_drive] ***
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

TASK [swift-storage-1 : format drive for swift using xfs] **********************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

TASK [swift-storage-1 : create swift.conf on swift node] ***********************
ok: [controller-2]
ok: [controller-3]
ok: [controller-1]
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be
removed in a future release. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

Fixed DEPRECATION Warnings:
ASK [swift-storage-1 : create swift.conf on swift node] ***********************
ok: [controller-2]
ok: [controller-3]
ok: [controller-1]
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{pdisk}}'). This feature will be removed in a future release. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.

TASK [nova-compute : create ovs bridges] ***************************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{neutron_ovs_bridges}}'). This feature will be removed in a future release. Deprecation warnings
can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [compute-1] => (item={u'bridge': u'br-ex', u'port': u'bond0.1805'})

TASK [nova-compute : configure ovs ports] **************************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{neutron_ovs_bridges}}'). This feature will be removed in a future release. Deprecation warnings
can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [compute-1] => (item={u'bridge': u'br-ex', u'port': u'bond0.1805'})
```
