### PR TITLE
adding role to configure lvm-cinder-volumes

### DIFF
--- a/compute-nodes.yml
+++ b/compute-nodes.yml
@@ -94,3 +94,4 @@
     - ceilometer-compute
     - nova-common
     - nova-compute
+    - cinder-volume-lvm

--- a/roles/cinder-volume-lvm/defaults/main.yml
+++ b/roles/cinder-volume-lvm/defaults/main.yml
@@ -1,0 +1,6 @@
+# Boolean operator to enable cinder installation
+cinder_volume_group_name: cinder-volumes
+cinder_lvm_backend_name: lvm
+
+
+

--- a/roles/cinder-volume-lvm/tasks/juno.yml
+++ b/roles/cinder-volume-lvm/tasks/juno.yml
@@ -1,0 +1,84 @@
+---
+# This is only meant to be used on compute systems, this will not provide HA to Volumes.
+- name: iptable rules for iscsi and cinder volume.
+  iptables:
+    port: "{{ item.port }}"
+    protocol: "{{ item.protocol}}"
+    comment: "{{item.comment}}"
+  with_items:
+    - { port: 3260, protocol: tcp, comment: "iscsi traffic incoming 3260"}
+
+- name: install cinder components
+  yum:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - openstack-cinder
+    - openstack-utils
+    - python-memcached
+    - python-keystonemiddleware
+    - python-openstackclient
+    - nfs-utils
+  tags: cinder
+
+- name: Update cinder config file
+  ini_file:
+    dest: /etc/cinder/cinder.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { section: "DEFAULT", option: "verbose", value: "true"}
+    - { section: "DEFAULT", option: "debug", value: "true"}
+    - { section: "DEFAULT", option: "auth_startegy", value: "keystone"}
+    - { section: "DEFAULT", option: "rabbit_hosts", value: "{{ rabbit_hosts }}"}
+    - { section: "DEFAULT", option: "rabbit_ha_queues", value: "true"}
+    - { section: "DEFAULT", option: "memcached_servers", value: "{{ memcache_list }}"}
+    - { section: "DEFAULT", option: "notification_driver", value: "messaging"}
+    - { section: "DEFAULT", option: "control_exchange", value: "cinder"}
+    - { section: "DEFAULT", option: "host", value: "{{ ansible_hostname }}"}
+    - { section: "DEFAULT", option: "osapi_volume_listen", value: "{{ cinder_osapi_volume_listen }}"}
+    - { section: "DEFAULT", option: "osapi_volume_listen_port", value: "{{ cinder_osapi_volume_listen_port | default (8776) }}"}
+    - { section: "database", option: "connection", value: "mysql://cinder:{{ cinder_db_pass }}@{{ lb_db_vip}}/cinder"}
+    - { section: "database", option: "max_retries", value: "-1"}
+  tags: cinder
+
+
+- name: Update configure cinder LVM driver
+  ini_file:
+    dest: /etc/cinder/cinder.conf
+    section: "{{ item.section }}"
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+  with_items:
+    - { section: "DEFAULT", option: "verbose", value: "true"}
+    - { section: "DEFUALT", option: "enabled_backends", value: "lvm"}
+    - { section: "LVM", option: "volume_driver", value: "cinder.volume.drivers.lvm.LVMISCSIDriver"}
+    - { section: "LVM", option: "iscsi_helper", value: "lioadm" }
+    - { section: "LVM", option: "volume_group", value: "{{ cinder_volume_group_name }}" }
+    - { section: "LVM", option: "iscsi_ip_address", value: "{{storage_if.ipaddr}}" }
+    - { section: "LVM", option: "volume_backend_name=", value: "{{cinder_lvm_backend_name}}" }
+
+- name: labeldisks provided to cinder
+  command: parted -s /dev/{{ item }} mklabel gpt
+  with_items: "{{pdisk}}"
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
+
+- name: create primary partition table
+  command: parted -s /dev/{{item}} unit mib mkpart primary 1 100%
+  with_items: "{{pdisk}}"
+  when: '"/dev/{{item|string()}}1" not in mounted_disk  and "{{item|string}}" != "sr0"'
+
+- name: run vgs
+  command: vgs
+  register: vgsoutput
+
+- name: create VG 
+  command: vgcreate {{ cinder_volume_group_name }} {{pvs_disks}} -y 
+  when: '"{{ cinder_volume_group_name }}" not in vgsoutput.stdout'
+- name: enable cinder-volume
+  service:
+    name: openstack-cinder-volume
+    enabled: yes
+    state: restarted
+

--- a/roles/cinder-volume-lvm/tasks/main.yml
+++ b/roles/cinder-volume-lvm/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: run cinder role based on juno release
+  include: juno.yml
+  when: openstack_release == 'juno' and lvm_cinder_volume

--- a/roles/cinder-volume-lvm/vars/main.yml
+++ b/roles/cinder-volume-lvm/vars/main.yml
@@ -1,0 +1,12 @@
+---
+mgmt_ipaddr: "{{ hostvars[inventory_hostname][ 'ansible_' + private_if ].ipv4.address }}"
+control_ipaddr: "{{ hostvars[inventory_hostname][ 'ansible_' + primary_if.device ].ipv4.address }}"
+cinder_osapi_volume_listen: "{{ mgmt_ipaddr }}"
+cinder_db_pass: "{{ lookup('password', credentials_dir + '/credentials/cinder_db_pass chars=ascii_letters,digits') }}"
+cinder_pass: "{{ lookup('password', credentials_dir + '/credentials/cinder_pass chars=ascii_letters,digits') }}"
+pvs_disks: '{% for disk in pdisk %}{% if disk|string() != "sda" %}{% if disk|string() != "sr0" %}/dev/{{disk}}1 {% endif %}{% endif %}{% endfor %}'
+pdisk_debug: '{% for disk in pdisk %}/dev/{{disk|string()}}1 {% endfor %}'
+pdisk: '[{% for disk in ansible_devices %}{% if disk|map(atribute="model") != "Virtual Floppy" %}"{{ disk }}"{% if not loop.last %}, {% endif %}{% endif %}{% endfor %} ]'
+mounted_disk: '[{% for disk in ansible_mounts %}"{{disk.device}}"{% if not loop.last %}, {% endif %}{% endfor %}]'
+rabbit_hosts: "{% for node in groups['controller'] %}{{ hostvars[node]['ansible_'+private_if]['ipv4']['address'] }}:{{rabbit_port}}{% if not loop.last %},{% endif %}{% endfor %}"
+memcache_list: "{% for node in groups['controller'] %}{{ hostvars[node]['ansible_'+private_if]['ipv4']['address'] }}:11211{% if not loop.last %},{% endif %}{% endfor %}"


### PR DESCRIPTION
Some users do not need an HA volume storage, This play and role provides LVM volume storage on compute nodes.  

Adding the following to the all.yml, will switch it.
`lvm_cinder_volume: True`

```
TASK [cinder-volume-lvm : install cinder components] ***************************
changed: [scaleio-3] => (item=[u'openstack-cinder', u'openstack-utils', u'python-memcached', u'python-keystonemiddleware', u'python-openstackclient', u'nfs-utils'])
changed: [compute-1] => (item=[u'openstack-cinder', u'openstack-utils', u'python-memcached', u'python-keystonemiddleware', u'python-openstackclient', u'nfs-utils'])
changed: [scaleio-2] => (item=[u'openstack-cinder', u'openstack-utils', u'python-memcached', u'python-keystonemiddleware', u'python-openstackclient', u'nfs-utils'])
changed: [scaleio-1] => (item=[u'openstack-cinder', u'openstack-utils', u'python-memcached', u'python-keystonemiddleware', u'python-openstackclient', u'nfs-utils'])

TASK [cinder-volume-lvm : Update cinder config file] ***************************
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'verbose', u'value': u'true'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'debug', u'value': u'true'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'auth_startegy', u'value': u'keystone'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'rabbit_hosts', u'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'rabbit_ha_queues', u'value': u'true'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'memcached_servers', u'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'notification_driver', u'value': u'messaging'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'control_exchange', u'value': u'cinder'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'host', u'value': u'scaleio-2'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'osapi_volume_listen', u'value': u'172.17.17.78'})
changed: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'osapi_volume_listen_port', u'value': u'8776'})
changed: [scaleio-2] => (item={u'section': u'database', u'option': u'connection', u'value': u'mysql://cinder:qamJTq1WN2wnXcme9ujg@172.17.17.101/cinder'})
changed: [scaleio-2] => (item={u'section': u'database', u'option': u'max_retries', u'value': u'-1'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'verbose', u'value': u'true'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'debug', u'value': u'true'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'auth_startegy', u'value': u'keystone'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'rabbit_hosts', u'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'rabbit_ha_queues', u'value': u'true'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'memcached_servers', u'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'notification_driver', u'value': u'messaging'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'control_exchange', u'value': u'cinder'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'host', u'value': u'compute-1'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'osapi_volume_listen', u'value': u'172.17.17.73'})
changed: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'osapi_volume_listen_port', u'value': u'8776'})
changed: [compute-1] => (item={u'section': u'database', u'option': u'connection', u'value': u'mysql://cinder:qamJTq1WN2wnXcme9ujg@172.17.17.101/cinder'})
changed: [compute-1] => (item={u'section': u'database', u'option': u'max_retries', u'value': u'-1'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'verbose', u'value': u'true'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'debug', u'value': u'true'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'auth_startegy', u'value': u'keystone'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'rabbit_hosts', u'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'rabbit_ha_queues', u'value': u'true'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'memcached_servers', u'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'notification_driver', u'value': u'messaging'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'control_exchange', u'value': u'cinder'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'host', u'value': u'scaleio-1'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'osapi_volume_listen', u'value': u'172.17.17.77'})
changed: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'osapi_volume_listen_port', u'value': u'8776'})
changed: [scaleio-1] => (item={u'section': u'database', u'option': u'connection', u'value': u'mysql://cinder:qamJTq1WN2wnXcme9ujg@172.17.17.101/cinder'})
changed: [scaleio-1] => (item={u'section': u'database', u'option': u'max_retries', u'value': u'-1'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'verbose', u'value': u'true'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'debug', u'value': u'true'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'auth_startegy', u'value': u'keystone'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'rabbit_hosts', u'value': u'172.17.17.70:5672,172.17.17.71:5672,172.17.17.72:5672'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'rabbit_ha_queues', u'value': u'true'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'memcached_servers', u'value': u'172.17.17.70:11211,172.17.17.71:11211,172.17.17.72:11211'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'notification_driver', u'value': u'messaging'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'control_exchange', u'value': u'cinder'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'host', u'value': u'scaleio-3'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'osapi_volume_listen', u'value': u'172.17.17.79'})
changed: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'osapi_volume_listen_port', u'value': u'8776'})
changed: [scaleio-3] => (item={u'section': u'database', u'option': u'connection', u'value': u'mysql://cinder:qamJTq1WN2wnXcme9ujg@172.17.17.101/cinder'})
changed: [scaleio-3] => (item={u'section': u'database', u'option': u'max_retries', u'value': u'-1'})

TASK [cinder-volume-lvm : Update configure cinder LVM driver] ******************
ok: [scaleio-1] => (item={u'section': u'DEFAULT', u'option': u'verbose', u'value': u'true'})
changed: [scaleio-1] => (item={u'section': u'DEFUALT', u'option': u'enabled_backends', u'value': u'lvm'})
changed: [scaleio-1] => (item={u'section': u'LVM', u'option': u'volume_driver', u'value': u'cinder.volume.drivers.lvm.LVMISCSIDriver'})
changed: [scaleio-1] => (item={u'section': u'LVM', u'option': u'iscsi_helper', u'value': u'lioadm'})
changed: [scaleio-1] => (item={u'section': u'LVM', u'option': u'volume_group', u'value': u'cinder-volumes'})
changed: [scaleio-1] => (item={u'section': u'LVM', u'option': u'iscsi_ip_address', u'value': u'172.17.19.77'})
changed: [scaleio-1] => (item={u'section': u'LVM', u'option': u'volume_backend_name=', u'value': u'lvm'})
ok: [scaleio-3] => (item={u'section': u'DEFAULT', u'option': u'verbose', u'value': u'true'})
changed: [scaleio-3] => (item={u'section': u'DEFUALT', u'option': u'enabled_backends', u'value': u'lvm'})
changed: [scaleio-3] => (item={u'section': u'LVM', u'option': u'volume_driver', u'value': u'cinder.volume.drivers.lvm.LVMISCSIDriver'})
changed: [scaleio-3] => (item={u'section': u'LVM', u'option': u'iscsi_helper', u'value': u'lioadm'})
changed: [scaleio-3] => (item={u'section': u'LVM', u'option': u'volume_group', u'value': u'cinder-volumes'})
changed: [scaleio-3] => (item={u'section': u'LVM', u'option': u'iscsi_ip_address', u'value': u'172.17.19.79'})
changed: [scaleio-3] => (item={u'section': u'LVM', u'option': u'volume_backend_name=', u'value': u'lvm'})
ok: [compute-1] => (item={u'section': u'DEFAULT', u'option': u'verbose', u'value': u'true'})
changed: [compute-1] => (item={u'section': u'DEFUALT', u'option': u'enabled_backends', u'value': u'lvm'})
changed: [compute-1] => (item={u'section': u'LVM', u'option': u'volume_driver', u'value': u'cinder.volume.drivers.lvm.LVMISCSIDriver'})
changed: [compute-1] => (item={u'section': u'LVM', u'option': u'iscsi_helper', u'value': u'lioadm'})
changed: [compute-1] => (item={u'section': u'LVM', u'option': u'volume_group', u'value': u'cinder-volumes'})
changed: [compute-1] => (item={u'section': u'LVM', u'option': u'iscsi_ip_address', u'value': u'172.17.19.73'})
changed: [compute-1] => (item={u'section': u'LVM', u'option': u'volume_backend_name=', u'value': u'lvm'})
ok: [scaleio-2] => (item={u'section': u'DEFAULT', u'option': u'verbose', u'value': u'true'})
changed: [scaleio-2] => (item={u'section': u'DEFUALT', u'option': u'enabled_backends', u'value': u'lvm'})
changed: [scaleio-2] => (item={u'section': u'LVM', u'option': u'volume_driver', u'value': u'cinder.volume.drivers.lvm.LVMISCSIDriver'})
changed: [scaleio-2] => (item={u'section': u'LVM', u'option': u'iscsi_helper', u'value': u'lioadm'})
changed: [scaleio-2] => (item={u'section': u'LVM', u'option': u'volume_group', u'value': u'cinder-volumes'})
changed: [scaleio-2] => (item={u'section': u'LVM', u'option': u'iscsi_ip_address', u'value': u'172.17.19.78'})
changed: [scaleio-2] => (item={u'section': u'LVM', u'option': u'volume_backend_name=', u'value': u'lvm'})

TASK [cinder-volume-lvm : labeldisks provided to cinder] ***********************
changed: [compute-1] => (item=sdd)
changed: [compute-1] => (item=sde)
changed: [compute-1] => (item=sdf)
changed: [compute-1] => (item=sdg)
skipping: [compute-1] => (item=sda)
changed: [compute-1] => (item=sdb)
changed: [compute-1] => (item=sdc)
changed: [scaleio-1] => (item=sdd)
changed: [scaleio-1] => (item=sde)
changed: [scaleio-1] => (item=sdf)
changed: [scaleio-1] => (item=sdg)
skipping: [scaleio-1] => (item=sda)
changed: [scaleio-1] => (item=sdb)
changed: [scaleio-1] => (item=sdc)
changed: [scaleio-1] => (item=sdh)
changed: [scaleio-2] => (item=sdd)
changed: [scaleio-2] => (item=sde)
changed: [scaleio-2] => (item=sdf)
changed: [scaleio-2] => (item=sdg)
skipping: [scaleio-2] => (item=sda)
changed: [scaleio-2] => (item=sdb)
changed: [scaleio-2] => (item=sdc)
changed: [scaleio-2] => (item=sdh)
changed: [scaleio-3] => (item=sdd)
changed: [scaleio-3] => (item=sde)
changed: [scaleio-3] => (item=sdf)
changed: [scaleio-3] => (item=sdg)
skipping: [scaleio-3] => (item=sda)
changed: [scaleio-3] => (item=sdb)
changed: [scaleio-3] => (item=sdc)
changed: [scaleio-3] => (item=sdh)

TASK [cinder-volume-lvm : create primary partition table] **********************
changed: [compute-1] => (item=sdd)
changed: [compute-1] => (item=sde)
changed: [compute-1] => (item=sdf)
changed: [compute-1] => (item=sdg)
skipping: [compute-1] => (item=sda)
changed: [compute-1] => (item=sdb)
changed: [compute-1] => (item=sdc)
changed: [scaleio-1] => (item=sdd)
changed: [scaleio-1] => (item=sde)
changed: [scaleio-1] => (item=sdf)
changed: [scaleio-1] => (item=sdg)
skipping: [scaleio-1] => (item=sda)
changed: [scaleio-1] => (item=sdb)
changed: [scaleio-1] => (item=sdc)
changed: [scaleio-1] => (item=sdh)
changed: [scaleio-2] => (item=sdd)
changed: [scaleio-2] => (item=sde)
changed: [scaleio-2] => (item=sdf)
changed: [scaleio-2] => (item=sdg)
skipping: [scaleio-2] => (item=sda)
changed: [scaleio-2] => (item=sdb)
changed: [scaleio-2] => (item=sdc)
changed: [scaleio-2] => (item=sdh)
changed: [scaleio-3] => (item=sdd)
changed: [scaleio-3] => (item=sde)
changed: [scaleio-3] => (item=sdf)
changed: [scaleio-3] => (item=sdg)
skipping: [scaleio-3] => (item=sda)
changed: [scaleio-3] => (item=sdb)
changed: [scaleio-3] => (item=sdc)
changed: [scaleio-3] => (item=sdh)

TASK [cinder-volume-lvm : run vgs] *********************************************
changed: [compute-1]
changed: [scaleio-1]
changed: [scaleio-2]
changed: [scaleio-3]

TASK [cinder-volume-lvm : create VG] *******************************************
skipping: [compute-1]
skipping: [scaleio-1]
skipping: [scaleio-2]
skipping: [scaleio-3]

TASK [cinder-volume-lvm : enable cinder-volume] ********************************
changed: [compute-1]
changed: [scaleio-1]
changed: [scaleio-2]
changed: [scaleio-3]
```

```
PLAY RECAP *********************************************************************
compute-1                  : ok=78   changed=63   unreachable=0    failed=0
controller-1               : ok=360  changed=300  unreachable=0    failed=0
controller-2               : ok=225  changed=175  unreachable=0    failed=0
controller-3               : ok=225  changed=175  unreachable=0    failed=0
scaleio-1                  : ok=78   changed=63   unreachable=0    failed=0
scaleio-2                  : ok=78   changed=63   unreachable=0    failed=0
scaleio-3                  : ok=78   changed=63   unreachable=0    failed=0
```

Checking the services and creating a volume.

```
[root@controller-1 ~(keystone_admin)]# cinder service-list
+------------------+-----------+------+---------+-------+----------------------------+-----------------+
|      Binary      |    Host   | Zone |  Status | State |         Updated_at         | Disabled Reason |
+------------------+-----------+------+---------+-------+----------------------------+-----------------+
| cinder-scheduler |   volume  | nova | enabled |   up  | 2016-02-12T20:35:47.000000 |       None      |
|  cinder-volume   | compute-1 | nova | enabled |   up  | 2016-02-12T20:35:50.000000 |       None      |
|  cinder-volume   | scaleio-1 | nova | enabled |   up  | 2016-02-12T20:35:49.000000 |       None      |
|  cinder-volume   | scaleio-2 | nova | enabled |   up  | 2016-02-12T20:35:47.000000 |       None      |
|  cinder-volume   | scaleio-3 | nova | enabled |   up  | 2016-02-12T20:35:44.000000 |       None      |
|  cinder-volume   |   volume  | nova | enabled |   up  | 2016-02-12T20:35:56.000000 |       None      |
+------------------+-----------+------+---------+-------+----------------------------+-----------------+
[root@controller-1 ~(keystone_admin)]# cinder create 5
+---------------------+--------------------------------------+
|       Property      |                Value                 |
+---------------------+--------------------------------------+
|     attachments     |                  []                  |
|  availability_zone  |                 nova                 |
|       bootable      |                false                 |
|      created_at     |      2016-02-12T20:36:03.910155      |
| display_description |                 None                 |
|     display_name    |                 None                 |
|      encrypted      |                False                 |
|          id         | 21431e44-b85f-462c-bfb7-cf252ccc23a3 |
|       metadata      |                  {}                  |
|         size        |                  5                   |
|     snapshot_id     |                 None                 |
|     source_volid    |                 None                 |
|        status       |               creating               |
|     volume_type     |                 None                 |
+---------------------+--------------------------------------+
[root@controller-1 ~(keystone_admin)]# cinder list
+--------------------------------------+-----------+--------------+------+-------------+----------+-------------+
|                  ID                  |   Status  | Display Name | Size | Volume Type | Bootable | Attached to |
+--------------------------------------+-----------+--------------+------+-------------+----------+-------------+
| 21431e44-b85f-462c-bfb7-cf252ccc23a3 | available |     None     |  5   |     None    |  false   |             |
+--------------------------------------+-----------+--------------+------+-------------+----------+-------------+
```
