### PR TITLE
Add glance_host line to cinder.conf on compute nodes.

### DIFF
--- a/roles/cinder-volume-lvm/tasks/juno.yml
+++ b/roles/cinder-volume-lvm/tasks/juno.yml
@@ -37,6 +37,7 @@
     - { section: "DEFAULT", option: "notification_driver", value: "messaging"}
     - { section: "DEFAULT", option: "control_exchange", value: "cinder"}
     - { section: "DEFAULT", option: "host", value: "{{ ansible_hostname }}"}
+    - { section: "DEFAULT", option: "glance_host", value: "{{ glance_vip }}"}
     - { section: "DEFAULT", option: "osapi_volume_listen", value: "{{ cinder_osapi_volume_listen }}"}
     - { section: "DEFAULT", option: "osapi_volume_listen_port", value: "{{ cinder_osapi_volume_listen_port | default (8776) }}"}
     - { section: "database", option: "connection", value: "mysql://cinder:{{ cinder_db_pass }}@{{ lb_db_vip}}/cinder"}


### PR DESCRIPTION
This PR addresses an issue where, cinder volumes could be made, but an image could not be downloaded to it during the creation phase.  THis was caused by the lack of the glance_host key in the cinder.conf file on the compute hosts.

```
PLAY RECAP *********************************************************************
compute-1                  : ok=52   changed=16   unreachable=0    failed=0
compute-2                  : ok=52   changed=16   unreachable=0    failed=0
compute-3                  : ok=52   changed=16   unreachable=0    failed=0
compute-4                  : ok=52   changed=16   unreachable=0    failed=0
controller-1               : ok=1    changed=0    unreachable=0    failed=0
controller-2               : ok=1    changed=0    unreachable=0    failed=0
controller-3               : ok=1    changed=0    unreachable=0    failed=0
scaleio-1                  : ok=52   changed=16   unreachable=0    failed=0
scaleio-2                  : ok=52   changed=16   unreachable=0    failed=0
scaleio-3                  : ok=52   changed=16   unreachable=0    failed=0
```

creating volume from image.

```
(keystone_admin)]# cinder create --image-id fc23d41e-c30f-40a2-a5b1-27010fe077fd 20
+---------------------+--------------------------------------+
|       Property      |                Value                 |
+---------------------+--------------------------------------+
|     attachments     |                  []                  |
|  availability_zone  |                 nova                 |
|       bootable      |                false                 |
|      created_at     |      2016-02-22T15:48:50.175937      |
| display_description |                 None                 |
|     display_name    |                 None                 |
|      encrypted      |                False                 |
|          id         | d008660a-4276-4654-a29b-677d3d1cf1f5 |
|       image_id      | fc23d41e-c30f-40a2-a5b1-27010fe077fd |
|       metadata      |                  {}                  |
|         size        |                  20                  |
|     snapshot_id     |                 None                 |
|     source_volid    |                 None                 |
|        status       |               creating               |
|     volume_type     |                 None                 |
+---------------------+--------------------------------------+
[root@controller-1 ~(keystone_admin)]# cinder show d008660a-4276-4654-a29b-677d3d1cf1f5
+---------------------------------------+--------------------------------------+
|                Property               |                Value                 |
+---------------------------------------+--------------------------------------+
|              attachments              |                  []                  |
|           availability_zone           |                 nova                 |
|                bootable               |                false                 |
|               created_at              |      2016-02-22T15:48:50.000000      |
|          display_description          |                 None                 |
|              display_name             |                 None                 |
|               encrypted               |                False                 |
|                   id                  | d008660a-4276-4654-a29b-677d3d1cf1f5 |
|                metadata               |                  {}                  |
|         os-vol-host-attr:host         |         scaleio-2#LVM_iSCSI          |
|     os-vol-mig-status-attr:migstat    |                 None                 |
|     os-vol-mig-status-attr:name_id    |                 None                 |
|      os-vol-tenant-attr:tenant_id     |   65dc43778c38481e85884ed349865eec   |
|   os-volume-replication:driver_data   |                 None                 |
| os-volume-replication:extended_status |                 None                 |
|                  size                 |                  20                  |
|              snapshot_id              |                 None                 |
|              source_volid             |                 None                 |
|                 status                |             downloading              |
|              volume_type              |                 None                 |
+---------------------------------------+--------------------------------------+
[root@controller-1 ~(keystone_admin)]# cinder show d008660a-4276-4654-a29b-677d3d1cf1f5
+---------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|                Property               |                                                                                                                          Value                                                                                                                          |
+---------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|              attachments              |                                                                                                                            []                                                                                                                           |
|           availability_zone           |                                                                                                                           nova                                                                                                                          |
|                bootable               |                                                                                                                           true                                                                                                                          |
|               created_at              |                                                                                                                2016-02-22T15:48:50.000000                                                                                                               |
|          display_description          |                                                                                                                           None                                                                                                                          |
|              display_name             |                                                                                                                           None                                                                                                                          |
|               encrypted               |                                                                                                                          False                                                                                                                          |
|                   id                  |                                                                                                           d008660a-4276-4654-a29b-677d3d1cf1f5                                                                                                          |
|                metadata               |                                                                                                                            {}                                                                                                                           |
|         os-vol-host-attr:host         |                                                                                                                   scaleio-2#LVM_iSCSI                                                                                                                   |
|     os-vol-mig-status-attr:migstat    |                                                                                                                           None                                                                                                                          |
|     os-vol-mig-status-attr:name_id    |                                                                                                                           None                                                                                                                          |
|      os-vol-tenant-attr:tenant_id     |                                                                                                             65dc43778c38481e85884ed349865eec                                                                                                            |
|   os-volume-replication:driver_data   |                                                                                                                           None                                                                                                                          |
| os-volume-replication:extended_status |                                                                                                                           None                                                                                                                          |
|                  size                 |                                                                                                                            20                                                                                                                           |
|              snapshot_id              |                                                                                                                           None                                                                                                                          |
|              source_volid             |                                                                                                                           None                                                                                                                          |
|                 status                |                                                                                                                        available                                                                                                                        |
|         volume_image_metadata         | {u'container_format': u'bare', u'min_ram': u'0', u'disk_format': u'qcow2', u'image_name': u'rhel7.2', u'image_id': u'fc23d41e-c30f-40a2-a5b1-27010fe077fd', u'checksum': u'486900b54f4757cb2d6b59d9bce9fe90', u'min_disk': u'0', u'size': u'474909696'} |
|              volume_type              |                                                                                                                           None                                                                                                                          |
+---------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
