### PR TITLE
Updating RHEL KVM guest image filename

### DIFF
--- a/roles/demo/defaults/main.yml
+++ b/roles/demo/defaults/main.yml
@@ -9,7 +9,7 @@ int_net_name: internal_net
 router_name: demo_router-1
 copy_image: True
 image_location: "/opt/autodeploy/resources/ISO/"
-image_name: rhel-guest-image-7.2-20151102.0.x86_64.qcow2
+image_name: rhel-guest-image-7.2-20160219.1.x86_64.qcow2
 image_disk_format: qcow2
 image_short_name: rhel7.2
 image_root_password: redhat1234


### PR DESCRIPTION
Updated as per changes on 2/24/2016 at https://access.redhat.com/downloads/content/69/ver=/rhel---7/7.2/x86_64/product-software
